### PR TITLE
BaseAuditEntity 생성 및 Swagger 의존성 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -29,6 +29,7 @@ dependencies {
     // json
     implementation 'org.json:json:20230227'
 
+    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.5.0'
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'org.springframework.boot:spring-boot-starter-web'

--- a/docs/tech-stack-architecture.md
+++ b/docs/tech-stack-architecture.md
@@ -84,6 +84,8 @@ src/main/java/com/sparta/deliveryorderplatform
 │   ├── exception
 │   │   ├── GlobalExceptionHandler.java
 │   │   └── CustomException.java
+│   ├── entity
+│   │   └── BaseTimeEntity.java
 │   └── common
 │       └── ApiResponse.java
 │

--- a/src/main/java/com/sparta/deliveryorderplatform/DeliveryOrderPlatformApplication.java
+++ b/src/main/java/com/sparta/deliveryorderplatform/DeliveryOrderPlatformApplication.java
@@ -2,8 +2,10 @@ package com.sparta.deliveryorderplatform;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @SpringBootApplication
+@EnableJpaAuditing
 public class DeliveryOrderPlatformApplication {
 
     public static void main(String[] args) {

--- a/src/main/java/com/sparta/deliveryorderplatform/global/common/ApiResponse.java
+++ b/src/main/java/com/sparta/deliveryorderplatform/global/common/ApiResponse.java
@@ -1,6 +1,10 @@
 package com.sparta.deliveryorderplatform.global.common;
 
+import java.util.List;
+
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.sparta.deliveryorderplatform.global.exception.ErrorCode;
+import com.sparta.deliveryorderplatform.global.exception.FieldError;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -10,22 +14,29 @@ import lombok.Getter;
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class ApiResponse<T> {
 
-	private int status; 	// HTTP 상태 코드
-	private String message; // "SUCCESS", "VALIDATION_ERROR" 등
-	private T data;			// 실제 응답 데이터
+	private int status;                // HTTP 상태 코드
+	private String code;
+	private String message;            // "SUCCESS", "VALIDATION_ERROR" 등
+	private T data;                        // 실제 응답 데이터
+	private List<FieldError> errors;    // 에러 상세 내용
 
 	// 성공 응답(반환 데이터 있는 경우)
-	public static <T> ApiResponse<T> success(T data) {
-		return new ApiResponse<>(200, "SUCCESS", data);
+	public static <T> ApiResponse<T> success (T data) {
+		return new ApiResponse<>(200, null, "SUCCESS", data, null);
 	}
 
 	// 성공 응답(반환 데이터 없는 경우)
-	public static <T> ApiResponse<T> success() {
-		return new ApiResponse<>(200, "SUCCESS", null);
+	public static <T> ApiResponse<T> success () {
+		return new ApiResponse<>(200, null, "SUCCESS", null, null);
 	}
 
 	// 에러 응답
-	public static ApiResponse<?> fail(int status, String message) {
-		return new ApiResponse<>(status, message, null);
+	public static ApiResponse<?> fail (ErrorCode errorCode) {
+		return new ApiResponse<>(errorCode.getStatus(), errorCode.getCode(), errorCode.getMessage(), null, null);
+	}
+
+	// 에러 응답
+	public static ApiResponse<?> fail (ErrorCode errorCode, List<FieldError> errors) {
+		return new ApiResponse<>(errorCode.getStatus(), errorCode.getCode(), errorCode.getMessage(), null, errors);
 	}
 }

--- a/src/main/java/com/sparta/deliveryorderplatform/global/common/ApiResponse.java
+++ b/src/main/java/com/sparta/deliveryorderplatform/global/common/ApiResponse.java
@@ -1,0 +1,31 @@
+package com.sparta.deliveryorderplatform.global.common;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class ApiResponse<T> {
+
+	private int status; 	// HTTP 상태 코드
+	private String message; // "SUCCESS", "VALIDATION_ERROR" 등
+	private T data;			// 실제 응답 데이터
+
+	// 성공 응답(반환 데이터 있는 경우)
+	public static <T> ApiResponse<T> success(T data) {
+		return new ApiResponse<>(200, "SUCCESS", data);
+	}
+
+	// 성공 응답(반환 데이터 없는 경우)
+	public static <T> ApiResponse<T> success() {
+		return new ApiResponse<>(200, "SUCCESS", null);
+	}
+
+	// 에러 응답
+	public static ApiResponse<?> fail(int status, String message) {
+		return new ApiResponse<>(status, message, null);
+	}
+}

--- a/src/main/java/com/sparta/deliveryorderplatform/global/common/PageResponse.java
+++ b/src/main/java/com/sparta/deliveryorderplatform/global/common/PageResponse.java
@@ -1,0 +1,34 @@
+package com.sparta.deliveryorderplatform.global.common;
+
+import java.util.List;
+
+import org.springframework.data.domain.Page;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class PageResponse<T> {
+
+	private List<T> content;
+	private int page;
+	private int size;
+	private long totalElements;
+	private int totalPages;
+	private String sort;
+
+	public static <T> PageResponse<T> of(Page<T> page) {
+		return new PageResponse<>(
+			page.getContent(),
+			page.getNumber(),
+			page.getSize(),
+			page.getTotalElements(),
+			page.getTotalPages(),
+			page.getSort().toString()
+		);
+	}
+}

--- a/src/main/java/com/sparta/deliveryorderplatform/global/config/JpaAuditingConfig.java
+++ b/src/main/java/com/sparta/deliveryorderplatform/global/config/JpaAuditingConfig.java
@@ -1,0 +1,19 @@
+package com.sparta.deliveryorderplatform.global.config;
+
+import java.util.Optional;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.domain.AuditorAware;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+@Configuration
+@EnableJpaAuditing
+public class JpaAuditingConfig {
+
+	@Bean
+	public AuditorAware<Long> auditorProvider() {
+		// 추후 JWT 구현 후 로그인 사용자ID가 들어가도록 수정할 예정
+		return () -> Optional.of(1L);
+	}
+}

--- a/src/main/java/com/sparta/deliveryorderplatform/global/entity/BaseAuditEntity.java
+++ b/src/main/java/com/sparta/deliveryorderplatform/global/entity/BaseAuditEntity.java
@@ -16,26 +16,31 @@ import lombok.Getter;
 @Getter
 @MappedSuperclass
 @EntityListeners(AuditingEntityListener.class)
-public class BaseAuditEntity {
+public abstract class BaseAuditEntity {
 
 	@CreatedDate
 	@Column(name = "created_at", nullable = false, updatable = false)
 	private LocalDateTime createdAt;
 
 	@CreatedBy
-	@Column(length = 100, updatable = false)
-	private String createdBy;
+	@Column(nullable = false, updatable = false)
+	private Long createdBy;
 
 	@LastModifiedDate
 	@Column(nullable = false)
 	private LocalDateTime updatedAt;
 
 	@LastModifiedBy
-	@Column(length = 100, nullable = false)
-	private String updatedBy;
+	@Column(nullable = false)
+	private Long updatedBy;
 
-	private LocalDateTime deltedAt;
+	private LocalDateTime deletedAt;
 
 	@Column(length = 100)
-	private String deletedBy;
+	private Long deletedBy;
+
+	public void softDelete(Long userId) {
+		this.deletedAt = LocalDateTime.now();
+		this.deletedBy = userId;
+	}
 }

--- a/src/main/java/com/sparta/deliveryorderplatform/global/entity/BaseAuditEntity.java
+++ b/src/main/java/com/sparta/deliveryorderplatform/global/entity/BaseAuditEntity.java
@@ -1,0 +1,41 @@
+package com.sparta.deliveryorderplatform.global.entity;
+
+import java.time.LocalDateTime;
+
+import org.springframework.data.annotation.CreatedBy;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedBy;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
+
+@Getter
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public class BaseAuditEntity {
+
+	@CreatedDate
+	@Column(name = "created_at", nullable = false, updatable = false)
+	private LocalDateTime createdAt;
+
+	@CreatedBy
+	@Column(length = 100, updatable = false)
+	private String createdBy;
+
+	@LastModifiedDate
+	@Column(nullable = false)
+	private LocalDateTime updatedAt;
+
+	@LastModifiedBy
+	@Column(length = 100, nullable = false)
+	private String updatedBy;
+
+	private LocalDateTime deltedAt;
+
+	@Column(length = 100)
+	private String deletedBy;
+}

--- a/src/main/java/com/sparta/deliveryorderplatform/global/exception/CustomException.java
+++ b/src/main/java/com/sparta/deliveryorderplatform/global/exception/CustomException.java
@@ -1,0 +1,10 @@
+package com.sparta.deliveryorderplatform.global.exception;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class CustomException extends RuntimeException {
+	private final ErrorCode errorCode;
+}

--- a/src/main/java/com/sparta/deliveryorderplatform/global/exception/ErrorCode.java
+++ b/src/main/java/com/sparta/deliveryorderplatform/global/exception/ErrorCode.java
@@ -8,8 +8,10 @@ import lombok.Getter;
 public enum ErrorCode {
 	// 에러별 enum값 추가하여 사용
 	// 400 BAD_REQUEST(예시)
-	INVALID_PASSWORD(400, "비밀번호가 올바르지 않습니다.");
+	VALIDATION_ERROR(400, "VALIDATION_ERROR", "요청 값이 올바르지 않습니다."),
+	INVALID_PASSWORD(400, "INVALID_PASSWORD", "비밀번호가 올바르지 않습니다.");
 
 	private final int status;
+	private final String code;
 	private final String message;
 }

--- a/src/main/java/com/sparta/deliveryorderplatform/global/exception/ErrorCode.java
+++ b/src/main/java/com/sparta/deliveryorderplatform/global/exception/ErrorCode.java
@@ -1,0 +1,15 @@
+package com.sparta.deliveryorderplatform.global.exception;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum ErrorCode {
+	// 에러별 enum값 추가하여 사용
+	// 400 BAD_REQUEST(예시)
+	INVALID_PASSWORD(400, "비밀번호가 올바르지 않습니다.");
+
+	private final int status;
+	private final String message;
+}

--- a/src/main/java/com/sparta/deliveryorderplatform/global/exception/FieldError.java
+++ b/src/main/java/com/sparta/deliveryorderplatform/global/exception/FieldError.java
@@ -1,0 +1,6 @@
+package com.sparta.deliveryorderplatform.global.exception;
+
+public record FieldError(
+	String field,
+	String message
+) {}

--- a/src/main/java/com/sparta/deliveryorderplatform/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/sparta/deliveryorderplatform/global/exception/GlobalExceptionHandler.java
@@ -1,6 +1,9 @@
 package com.sparta.deliveryorderplatform.global.exception;
 
+import java.util.List;
+
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice; // 추가
 
@@ -14,6 +17,25 @@ public class GlobalExceptionHandler {
 		ErrorCode errorCode = e.getErrorCode();
 		return ResponseEntity
 			.status(errorCode.getStatus())
-			.body(ApiResponse.fail(errorCode.getStatus(), errorCode.getMessage()));
+			.body(ApiResponse.fail(errorCode));
+	}
+
+	@ExceptionHandler(MethodArgumentNotValidException.class)
+	public ResponseEntity<ApiResponse<?>> handleValidationException(MethodArgumentNotValidException e) {
+
+		List<FieldError> errors = e.getBindingResult()
+			.getFieldErrors()
+			.stream()
+			.map(error -> new FieldError(
+				error.getField(),
+				error.getDefaultMessage()
+			))
+			.toList();
+
+		ErrorCode errorCode = ErrorCode.VALIDATION_ERROR;
+
+		return ResponseEntity
+			.status(errorCode.getStatus())
+			.body(ApiResponse.fail(errorCode, errors));
 	}
 }

--- a/src/main/java/com/sparta/deliveryorderplatform/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/sparta/deliveryorderplatform/global/exception/GlobalExceptionHandler.java
@@ -1,0 +1,19 @@
+package com.sparta.deliveryorderplatform.global.exception;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice; // 추가
+
+import com.sparta.deliveryorderplatform.global.common.ApiResponse;
+
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+	@ExceptionHandler(CustomException.class)
+	public ResponseEntity<ApiResponse<?>> handleCustomException(CustomException e) {
+		ErrorCode errorCode = e.getErrorCode();
+		return ResponseEntity
+			.status(errorCode.getStatus())
+			.body(ApiResponse.fail(errorCode.getStatus(), errorCode.getMessage()));
+	}
+}


### PR DESCRIPTION
## ✨ 작업 내용
> BaseAuditEntity.java 추가 및 JPA Auditing 적용
> Swagger를 위한 Springdoc의존성 추가

## 📸 스크린샷(선택)
> 스크린샷이 필요한 작업이면 스크린샷을 첨부해주세요

## ✅ 테스트

## 📚 레퍼런스 (또는 새로 알게 된 내용) 혹은 궁금한 사항들
> createdAt, createdBy, updatedAt, updatedBy, deletedAt, deletedBy 필드가 모두 필요한 Entity에서는 BaseAuditEntity 상속받아 사용하시면 됩니다.