### PR TITLE
Feature/user

### DIFF
--- a/src/main/java/com/sparta/deliveryorderplatform/auth/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/sparta/deliveryorderplatform/auth/jwt/JwtAuthenticationFilter.java
@@ -1,11 +1,11 @@
 package com.sparta.deliveryorderplatform.auth.jwt;
 
 import java.io.IOException;
-import java.util.List;
 
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
-import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.web.filter.OncePerRequestFilter;
 
 import com.sparta.deliveryorderplatform.global.exception.ErrorCode;
@@ -22,6 +22,7 @@ import lombok.extern.slf4j.Slf4j;
 public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
 	private final JwtTokenProvider jwtTokenProvider;
+	private final UserDetailsService userDetailsService;
 
 	/*
 	 * 필터의 핵심 로직
@@ -41,17 +42,16 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 		if (token != null) {
 			try {
 				if (jwtTokenProvider.validateToken(token)) {
-					// 토큰에서 사용자 아이디와 권한을 꺼낸다.
+					// 토큰에서 사용자 아이디를 꺼낸다.
 					String username = jwtTokenProvider.getUsername(token);
-					String role = jwtTokenProvider.getRole(token);
 
-					// 3. Spring Security가 인식할 수 있는 Authority 리스트를 만든다.
-					List<SimpleGrantedAuthority> authorities = List.of(new SimpleGrantedAuthority(role));
+					// 3. DB 조회를 통해 UserDetailsImpl 객체 생성
+					UserDetails userDetails = userDetailsService.loadUserByUsername(username);
 
 					// 4. 인증된 사용자 정보를 담은 인증 객체(Authentication)를 생성한다.
 					// (비밀번호는 이미 토큰으로 검증되었으므로 null로 둔다.)
 					UsernamePasswordAuthenticationToken auth =
-						new UsernamePasswordAuthenticationToken(username, null, authorities);
+						new UsernamePasswordAuthenticationToken(userDetails, null, userDetails.getAuthorities());
 
 					// 5. SecurityContext에 이 인증 정보를 담아둔다.
 					// 이제 이후 로직에서 이 사용자가 누구인지 알 수 있게 된다.

--- a/src/main/java/com/sparta/deliveryorderplatform/global/config/JpaAuditingConfig.java
+++ b/src/main/java/com/sparta/deliveryorderplatform/global/config/JpaAuditingConfig.java
@@ -6,6 +6,9 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.domain.AuditorAware;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.security.authentication.AnonymousAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
 
 @Configuration
 @EnableJpaAuditing
@@ -13,7 +16,19 @@ public class JpaAuditingConfig {
 
 	@Bean
 	public AuditorAware<String> auditorProvider() {
-		// 추후 JWT 구현 후 로그인 사용자ID가 들어가도록 수정할 예정
-		return () -> Optional.of("admin");
+		return () -> {
+			// SecurityContext에서 인증 정보 가져오기
+			Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+
+			// 인증 정보가 없거나 익명 사용자인 경우 처리
+			if (authentication == null ||
+				!authentication.isAuthenticated() ||
+				authentication instanceof AnonymousAuthenticationToken) {
+				return Optional.empty();
+			}
+
+			// 현재 로그인한 사용자의 username 반환
+			return Optional.ofNullable(authentication.getName());
+		};
 	}
 }

--- a/src/main/java/com/sparta/deliveryorderplatform/global/config/SecurityConfig.java
+++ b/src/main/java/com/sparta/deliveryorderplatform/global/config/SecurityConfig.java
@@ -2,9 +2,11 @@ package com.sparta.deliveryorderplatform.global.config;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
@@ -17,11 +19,13 @@ import lombok.RequiredArgsConstructor;
 
 @Configuration
 @EnableWebSecurity
+@EnableMethodSecurity
 @RequiredArgsConstructor
 public class SecurityConfig {
 
 	private final JwtTokenProvider jwtTokenProvider;
 	private final JwtAuthenticationEntryPoint jwtAuthenticationEntryPoint;
+	private final UserDetailsService userDetailsService;
 
 	@Bean
 	public BCryptPasswordEncoder bCryptPasswordEncoder() {
@@ -50,7 +54,7 @@ public class SecurityConfig {
 			)
 			// 미리 만들어둔 JwtAuthenticationFilter를
 			// UsernamePasswordAuthenticationFilter(기본 로그인 필터) 보다 먼저 실행되게 끼워 넣는다.
-			.addFilterBefore(new JwtAuthenticationFilter(jwtTokenProvider),
+			.addFilterBefore(new JwtAuthenticationFilter(jwtTokenProvider, userDetailsService),
 							UsernamePasswordAuthenticationFilter.class);
 
 		return http.build();

--- a/src/main/java/com/sparta/deliveryorderplatform/global/entity/BaseAuditEntity.java
+++ b/src/main/java/com/sparta/deliveryorderplatform/global/entity/BaseAuditEntity.java
@@ -39,8 +39,8 @@ public abstract class BaseAuditEntity {
 	@Column(length = 100)
 	private String deletedBy;
 
-	public void softDelete(String user) {
+	public void softDelete(String username) {
 		this.deletedAt = LocalDateTime.now();
-		this.deletedBy = user;
+		this.deletedBy = username;
 	}
 }

--- a/src/main/java/com/sparta/deliveryorderplatform/global/exception/ErrorCode.java
+++ b/src/main/java/com/sparta/deliveryorderplatform/global/exception/ErrorCode.java
@@ -6,13 +6,19 @@ import lombok.Getter;
 @Getter
 @AllArgsConstructor
 public enum ErrorCode {
-	// auth
 	VALIDATION_ERROR(400, "VALIDATION_ERROR", "요청 값이 올바르지 않습니다."),
+
+	// auth
 	LOGIN_FAILED(400, "LOGIN_FAILED", "아이디 또는 비밀번호가 일치하지 않습니다."),
-	DUPLICATE_USERNAME(400, "DUPLICATE_USERNAME", "이미 존재하는 아이디입니다."),
-	DUPLICATE_EMAIL(400, "DUPLICATE_EMAIL", "이미 사용 중인 이메일입니다."),
 	INVALID_ROLE_SELECTION(400, "INVALID_ROLE_SELECTION", "가입할 수 없는 권한입니다."),
   	UNAUTHORIZED_ACCESS(403, "UNAUTHORIZED_ACCESS", "접근 권한이 없습니다."),
+	ACCESS_DENIED(403, "ACCESS_DENIED", "해당 요청에 대한 권한이 없습니다."),
+
+	// --- 유저 관련 (USER) ---
+	USER_NOT_FOUND(404, "USER_NOT_FOUND", "해당 사용자를 찾을 수 없습니다."),
+	DUPLICATE_USERNAME(400, "DUPLICATE_USERNAME", "이미 존재하는 아이디입니다."),
+	DUPLICATE_EMAIL(400, "DUPLICATE_EMAIL", "이미 사용 중인 이메일입니다."),
+	INVALID_PASSWORD(400, "INVALID_PASSWORD", "비밀번호가 일치하지 않습니다."),
 
 	// menu
 	MENU_NOT_FOUND(404, "MENU_NOT_FOUND", "해당 상품이 존재하지 않습니다."),

--- a/src/main/java/com/sparta/deliveryorderplatform/user/controller/UserController.java
+++ b/src/main/java/com/sparta/deliveryorderplatform/user/controller/UserController.java
@@ -46,7 +46,6 @@ public class UserController {
 
 	// 사용자 상세 조회
 	@GetMapping("/{username}")
-	@PreAuthorize("hasAnyRole('MASTER')")
 	public ResponseEntity<ApiResponse<UserResponseDto>> getUser(
 		@PathVariable String username,
 		@AuthenticationPrincipal UserDetailsImpl userDetails

--- a/src/main/java/com/sparta/deliveryorderplatform/user/controller/UserController.java
+++ b/src/main/java/com/sparta/deliveryorderplatform/user/controller/UserController.java
@@ -1,0 +1,99 @@
+package com.sparta.deliveryorderplatform.user.controller;
+
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.sparta.deliveryorderplatform.global.common.ApiResponse;
+import com.sparta.deliveryorderplatform.global.common.PageResponse;
+import com.sparta.deliveryorderplatform.user.dto.PasswordChangeRequestDto;
+import com.sparta.deliveryorderplatform.user.dto.UserResponseDto;
+import com.sparta.deliveryorderplatform.user.dto.UserRoleUpdateRequestDto;
+import com.sparta.deliveryorderplatform.user.dto.UserSearchCondition;
+import com.sparta.deliveryorderplatform.user.dto.UserUpdateRequestDto;
+import com.sparta.deliveryorderplatform.user.security.UserDetailsImpl;
+import com.sparta.deliveryorderplatform.user.service.UserService;
+
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequestMapping("/api/v1/users")
+@RequiredArgsConstructor
+public class UserController {
+
+	private final UserService userService;
+
+	// 사용자 목록 조회 (MASTER만 가능)
+	@GetMapping
+	@PreAuthorize("hasAnyRole('MASTER')")
+	public ResponseEntity<ApiResponse<PageResponse<UserResponseDto>>> getUsers(
+		UserSearchCondition condition,
+		@PageableDefault(size = 10, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable
+	) {
+		return ResponseEntity.ok(ApiResponse.success(PageResponse.of(userService.getUsers(condition, pageable))));
+	}
+
+	// 사용자 상세 조회
+	@GetMapping("/{username}")
+	@PreAuthorize("hasAnyRole('MASTER')")
+	public ResponseEntity<ApiResponse<UserResponseDto>> getUser(
+		@PathVariable String username,
+		@AuthenticationPrincipal UserDetailsImpl userDetails
+	) {
+		return ResponseEntity.ok(ApiResponse.success(userService.getUser(username,userDetails.getUser())));
+	}
+
+	// 사용자 정보 수정
+	@PutMapping("/{username}")
+	public ResponseEntity<ApiResponse<UserResponseDto>> updateUser(
+		@PathVariable String username,
+		@Valid @RequestBody UserUpdateRequestDto requestDto,
+		@AuthenticationPrincipal UserDetailsImpl userDetails
+	) {
+		return ResponseEntity.ok(ApiResponse.success(userService.updateUser(username, requestDto, userDetails.getUser())));
+	}
+
+	// 사용자 삭제
+	@PatchMapping("/{username}")
+	public ResponseEntity<ApiResponse<Void>> deleteUser(
+		@PathVariable String username,
+		@AuthenticationPrincipal UserDetailsImpl userDetails
+	) {
+		userService.deleteUser(username, userDetails.getUser());
+		return ResponseEntity.ok(ApiResponse.success());
+	}
+
+	// 사용자 권한 수정
+	@PutMapping("/{username}/role")
+	@PreAuthorize("hasRole('MASTER')")
+	public ResponseEntity<ApiResponse<Void>> updateUserRole(
+		@PathVariable String username,
+		@RequestBody UserRoleUpdateRequestDto requestDto,
+		@AuthenticationPrincipal UserDetailsImpl userDetails
+	) {
+		userService.updateUserRole(username, requestDto, userDetails.getUser());
+		return ResponseEntity.ok(ApiResponse.success());
+	}
+
+	// 비밀번호 변경
+	@PatchMapping("/{username}/password")
+	public ResponseEntity<ApiResponse<Void>> updatePassword(
+		@PathVariable String username,
+		@RequestBody @Valid PasswordChangeRequestDto requestDto,
+		@AuthenticationPrincipal UserDetailsImpl userDetails
+	) {
+		userService.updatePassword(username, requestDto, userDetails.getUser());
+		return ResponseEntity.ok(ApiResponse.success(null));
+	}
+}

--- a/src/main/java/com/sparta/deliveryorderplatform/user/dto/PasswordChangeRequestDto.java
+++ b/src/main/java/com/sparta/deliveryorderplatform/user/dto/PasswordChangeRequestDto.java
@@ -1,0 +1,14 @@
+package com.sparta.deliveryorderplatform.user.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+
+public record PasswordChangeRequestDto(
+	@NotBlank
+	String currentPassword,
+
+	@NotBlank(message = "비밀번호를 입력해주세요.")
+	@Pattern(regexp = "^(?=.*[a-z])(?=.*[A-Z])(?=.*\\d)(?=.*[@$!%*?&])[A-Za-z\\d@$!%*?&]{8,15}$",
+		message = "비밀번호는 8~15자 영문 대소문자, 숫자, 특수문자를 포함해야 합니다.")
+	String newPassword
+) {}

--- a/src/main/java/com/sparta/deliveryorderplatform/user/dto/UserResponseDto.java
+++ b/src/main/java/com/sparta/deliveryorderplatform/user/dto/UserResponseDto.java
@@ -1,0 +1,26 @@
+package com.sparta.deliveryorderplatform.user.dto;
+
+import java.time.LocalDateTime;
+
+import com.sparta.deliveryorderplatform.user.entity.User;
+import com.sparta.deliveryorderplatform.user.entity.UserRole;
+
+public record UserResponseDto(
+	String username,
+	String nickname,
+	String email,
+	UserRole role,
+	boolean isPublic,
+	LocalDateTime createdAt
+) {
+	public static UserResponseDto from(User user) {
+		return new UserResponseDto(
+			user.getUsername(),
+			user.getNickname(),
+			user.getEmail(),
+			user.getRole(),
+			user.getIsPublic(),
+			user.getCreatedAt()
+		);
+	}
+}

--- a/src/main/java/com/sparta/deliveryorderplatform/user/dto/UserRoleUpdateRequestDto.java
+++ b/src/main/java/com/sparta/deliveryorderplatform/user/dto/UserRoleUpdateRequestDto.java
@@ -1,0 +1,10 @@
+package com.sparta.deliveryorderplatform.user.dto;
+
+import com.sparta.deliveryorderplatform.user.entity.UserRole;
+
+import jakarta.validation.constraints.NotNull;
+
+public record UserRoleUpdateRequestDto(
+	@NotNull(message = "변경할 권한을 선택해주세요.")
+	UserRole role
+) {}

--- a/src/main/java/com/sparta/deliveryorderplatform/user/dto/UserSearchCondition.java
+++ b/src/main/java/com/sparta/deliveryorderplatform/user/dto/UserSearchCondition.java
@@ -1,0 +1,9 @@
+package com.sparta.deliveryorderplatform.user.dto;
+
+import com.sparta.deliveryorderplatform.user.entity.UserRole;
+
+public record UserSearchCondition(
+	String username,
+	String nickname,
+	UserRole role
+) {}

--- a/src/main/java/com/sparta/deliveryorderplatform/user/dto/UserUpdateRequestDto.java
+++ b/src/main/java/com/sparta/deliveryorderplatform/user/dto/UserUpdateRequestDto.java
@@ -1,0 +1,12 @@
+package com.sparta.deliveryorderplatform.user.dto;
+
+import jakarta.validation.constraints.Email;
+
+public record UserUpdateRequestDto(
+		String nickname,
+
+		@Email(message = "올바른 이메일 형식이 아닙니다.")
+		String email,
+
+		Boolean isPublic
+) {}

--- a/src/main/java/com/sparta/deliveryorderplatform/user/entity/User.java
+++ b/src/main/java/com/sparta/deliveryorderplatform/user/entity/User.java
@@ -42,7 +42,7 @@ public class User extends BaseAuditEntity {
 
 	@Builder.Default
 	@Column(nullable = false)
-	private boolean isPublic = true;	// 사용자 정보 공개 여부(기본값 true)
+	private Boolean isPublic = true;	// 사용자 정보 공개 여부(기본값 true)
 
 	public static User createUser(String username, String nickname, String email, String password, UserRole role) {
 		if (username == null || username.isBlank()) throw new CustomException(ErrorCode.VALIDATION_ERROR);
@@ -61,7 +61,27 @@ public class User extends BaseAuditEntity {
 			.build();
 	}
 
-	public void updateNickname(String nickname) {
-		this.nickname = nickname;
+	public void updateProfile(String nickname, String email, Boolean isPublic) {
+		if (nickname != null && !nickname.isBlank()) {
+			this.nickname = nickname;
+		}
+		if (email != null && !email.isBlank()) {
+			this.email = email;
+		}
+		if (isPublic != null) {
+			this.isPublic = isPublic;
+		}
+	}
+
+	public void updatePassword(String encodedPassword) {
+		this.password = encodedPassword;
+	}
+
+	public void updateRole(UserRole newRole) {
+		if (newRole == null) {
+			throw new CustomException(ErrorCode.INVALID_ROLE_SELECTION);
+		}
+
+		this.role = newRole;
 	}
 }

--- a/src/main/java/com/sparta/deliveryorderplatform/user/entity/UserRole.java
+++ b/src/main/java/com/sparta/deliveryorderplatform/user/entity/UserRole.java
@@ -21,7 +21,6 @@ public enum UserRole {
 	public static class Authority {
 		public static final String CUSTOMER = "ROLE_CUSTOMER";
 		public static final String OWNER = "ROLE_OWNER";
-		public static final String MANAGER = "ROLE_MANAGER";
 		public static final String MASTER = "ROLE_MASTER";
 	}
 }

--- a/src/main/java/com/sparta/deliveryorderplatform/user/entity/UserRole.java
+++ b/src/main/java/com/sparta/deliveryorderplatform/user/entity/UserRole.java
@@ -1,14 +1,27 @@
 package com.sparta.deliveryorderplatform.user.entity;
 
 import lombok.Getter;
-import lombok.RequiredArgsConstructor;
 
 @Getter
-@RequiredArgsConstructor
 public enum UserRole {
 	CUSTOMER("ROLE_CUSTOMER"), 	// 고객 권한
 	OWNER("ROLE_OWNER"),		// 가게 사장 권한
 	MASTER("ROLE_MASTER");		// 관리자 권한
 
 	private final String authority;
+
+	UserRole(String authority) {
+		this.authority = authority;
+	}
+
+	public String getAuthority() {
+		return this.authority;
+	}
+
+	public static class Authority {
+		public static final String CUSTOMER = "ROLE_CUSTOMER";
+		public static final String OWNER = "ROLE_OWNER";
+		public static final String MANAGER = "ROLE_MANAGER";
+		public static final String MASTER = "ROLE_MASTER";
+	}
 }

--- a/src/main/java/com/sparta/deliveryorderplatform/user/repository/UserRepository.java
+++ b/src/main/java/com/sparta/deliveryorderplatform/user/repository/UserRepository.java
@@ -9,7 +9,7 @@ import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 
 @Repository
-public interface UserRepository extends JpaRepository<User, String> {
+public interface UserRepository extends JpaRepository<User, String>, UserRepositoryCustom {
 
 	boolean existsByEmail (@NotBlank(message = "이메일을 입력해주세요.") @Email String email);
 }

--- a/src/main/java/com/sparta/deliveryorderplatform/user/repository/UserRepositoryCustom.java
+++ b/src/main/java/com/sparta/deliveryorderplatform/user/repository/UserRepositoryCustom.java
@@ -1,0 +1,11 @@
+package com.sparta.deliveryorderplatform.user.repository;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+import com.sparta.deliveryorderplatform.user.dto.UserSearchCondition;
+import com.sparta.deliveryorderplatform.user.entity.User;
+
+public interface UserRepositoryCustom {
+	Page<User> searchUsers(UserSearchCondition condition, Pageable pageable);
+}

--- a/src/main/java/com/sparta/deliveryorderplatform/user/repository/UserRepositoryImpl.java
+++ b/src/main/java/com/sparta/deliveryorderplatform/user/repository/UserRepositoryImpl.java
@@ -1,0 +1,70 @@
+package com.sparta.deliveryorderplatform.user.repository;
+
+import static com.sparta.deliveryorderplatform.user.entity.QUser.*;
+import static org.springframework.util.StringUtils.*;
+
+import java.util.List;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.support.PageableExecutionUtils;
+
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQuery;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.sparta.deliveryorderplatform.user.dto.UserSearchCondition;
+import com.sparta.deliveryorderplatform.user.entity.User;
+import com.sparta.deliveryorderplatform.user.entity.UserRole;
+
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public class UserRepositoryImpl implements UserRepositoryCustom {
+
+	private final JPAQueryFactory queryFactory;
+
+	@Override
+	public Page<User> searchUsers(UserSearchCondition condition, Pageable pageable) {
+		// 1. 콘텐츠 조회용 쿼리
+		List<User> content = queryFactory
+			.selectFrom(user)
+			.where(
+				usernameEq(condition.username()),
+				nicknameContains(condition.nickname()),
+				roleEq(condition.role()),
+				user.deletedAt.isNull() // 소프트 삭제 제외
+			)
+			.orderBy(user.createdAt.desc()) // 기본 정렬 (필요시 Pageable의 sort 적용 가능)
+			.offset(pageable.getOffset())
+			.limit(pageable.getPageSize())
+			.fetch();
+
+		// 2. 카운트 쿼리 (성능 최적화용)
+		JPAQuery<Long> countQuery = queryFactory
+			.select(user.count())
+			.from(user)
+			.where(
+				usernameEq(condition.username()),
+				nicknameContains(condition.nickname()),
+				roleEq(condition.role()),
+				user.deletedAt.isNull()
+			);
+
+		// 3. Page 객체 반환 (PageableExecutionUtils 사용 시 카운트 쿼리 최적화 가능)
+		return PageableExecutionUtils.getPage(content, pageable, countQuery::fetchOne);
+	}
+
+	// --- 동적 조건 메서드 (BooleanExpression) ---
+
+	private BooleanExpression usernameEq(String username) {
+		return hasText(username) ? user.username.eq(username) : null;
+	}
+
+	private BooleanExpression nicknameContains(String nickname) {
+		return hasText(nickname) ? user.nickname.contains(nickname) : null;
+	}
+
+	private BooleanExpression roleEq(UserRole role) {
+		return role != null ? user.role.eq(role) : null;
+	}
+}

--- a/src/main/java/com/sparta/deliveryorderplatform/user/security/UserDetailsImpl.java
+++ b/src/main/java/com/sparta/deliveryorderplatform/user/security/UserDetailsImpl.java
@@ -1,0 +1,59 @@
+package com.sparta.deliveryorderplatform.user.security;
+
+import java.util.ArrayList;
+import java.util.Collection;
+
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import com.sparta.deliveryorderplatform.user.entity.User;
+import com.sparta.deliveryorderplatform.user.entity.UserRole;
+
+public class UserDetailsImpl implements UserDetails {
+
+	private final User user;
+
+	public UserDetailsImpl(User user) {
+		this.user = user;
+	}
+
+	public User getUser() {
+		return user;
+	}
+
+	@Override
+	public String getPassword() {
+		return user.getPassword();
+	}
+
+	@Override
+	public String getUsername() {
+		return user.getUsername();
+	}
+
+	// 권한 설정 (UserRole을 GrantedAuthority로 변환)
+	@Override
+	public Collection<? extends GrantedAuthority> getAuthorities() {
+		UserRole role = user.getRole();
+		String authority = role.getAuthority(); // 이전에 만든 "ROLE_CUSTOMER" 등 반환 메서드
+
+		SimpleGrantedAuthority simpleGrantedAuthority = new SimpleGrantedAuthority(authority);
+		Collection<GrantedAuthority> authorities = new ArrayList<>();
+		authorities.add(simpleGrantedAuthority);
+
+		return authorities;
+	}
+
+	@Override
+	public boolean isAccountNonExpired() { return true; }
+
+	@Override
+	public boolean isAccountNonLocked() { return true; }
+
+	@Override
+	public boolean isCredentialsNonExpired() { return true; }
+
+	@Override
+	public boolean isEnabled() { return true; }
+}

--- a/src/main/java/com/sparta/deliveryorderplatform/user/security/UserDetailsServiceImpl.java
+++ b/src/main/java/com/sparta/deliveryorderplatform/user/security/UserDetailsServiceImpl.java
@@ -1,0 +1,26 @@
+package com.sparta.deliveryorderplatform.user.security;
+
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+
+import com.sparta.deliveryorderplatform.user.entity.User;
+import com.sparta.deliveryorderplatform.user.repository.UserRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class UserDetailsServiceImpl implements UserDetailsService {
+
+	private final UserRepository userRepository;
+
+	@Override
+	public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
+		User user = userRepository.findById(username)
+			.orElseThrow(() -> new UsernameNotFoundException("Not Found " + username));
+
+		return new UserDetailsImpl(user);
+	}
+}

--- a/src/main/java/com/sparta/deliveryorderplatform/user/service/UserService.java
+++ b/src/main/java/com/sparta/deliveryorderplatform/user/service/UserService.java
@@ -1,0 +1,106 @@
+package com.sparta.deliveryorderplatform.user.service;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.sparta.deliveryorderplatform.global.exception.CustomException;
+import com.sparta.deliveryorderplatform.global.exception.ErrorCode;
+import com.sparta.deliveryorderplatform.user.dto.PasswordChangeRequestDto;
+import com.sparta.deliveryorderplatform.user.dto.UserResponseDto;
+import com.sparta.deliveryorderplatform.user.dto.UserRoleUpdateRequestDto;
+import com.sparta.deliveryorderplatform.user.dto.UserSearchCondition;
+import com.sparta.deliveryorderplatform.user.dto.UserUpdateRequestDto;
+import com.sparta.deliveryorderplatform.user.entity.User;
+import com.sparta.deliveryorderplatform.user.entity.UserRole;
+import com.sparta.deliveryorderplatform.user.repository.UserRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class UserService {
+
+	private final UserRepository userRepository;
+	private final BCryptPasswordEncoder passwordEncoder;
+
+	public Page<UserResponseDto> getUsers (UserSearchCondition condition, Pageable pageable) {
+		Page<User> userPage = userRepository.searchUsers(condition, pageable);
+		return userPage.map(UserResponseDto::from);
+	}
+
+	public UserResponseDto getUser(String username, User loginUser) {
+		checkPermission(username, loginUser);
+		User user = findById(username);
+		return UserResponseDto.from(user);
+	}
+
+	@Transactional
+	public UserResponseDto updateUser(String username, UserUpdateRequestDto requestDto, User loginUser) {
+		checkPermission(username, loginUser);
+		User user = findById(username);
+
+		// 공통 수정 필드 (닉네임, 이메일, 공개여부) - 본인/MASTER 가능
+		user.updateProfile(requestDto.nickname(), requestDto.email(), requestDto.isPublic());
+
+		// 필요 시 다른 필드 업데이트 로직 추가
+		return UserResponseDto.from(user);
+	}
+
+	public void updatePassword(String username, PasswordChangeRequestDto requestDto, User loginUser) {
+		// 1. 본인 확인 (비밀번호 변경은 관리자도 불가능)
+		if (!loginUser.getUsername().equals(username)) {
+			throw new CustomException(ErrorCode.ACCESS_DENIED);
+		}
+
+		User user = findById(username);
+
+		// 2. 현재 비밀번호 일치 여부 확인
+		if (!passwordEncoder.matches(requestDto.currentPassword(), user.getPassword())) {
+			throw new CustomException(ErrorCode.INVALID_PASSWORD); // 비밀번호 불일치 에러
+		}
+
+		// 3. 새 비밀번호 암호화 및 업데이트
+		user.updatePassword(passwordEncoder.encode(requestDto.newPassword()));
+	}
+
+	public void updateUserRole (String username, UserRoleUpdateRequestDto requestDto, User loginUser) {
+		if (loginUser.getRole() != UserRole.MASTER) {
+			throw new CustomException(ErrorCode.ACCESS_DENIED);
+		}
+
+		User user = findById(username);
+
+		if (user.getUsername().equals(loginUser.getUsername())) {
+			throw new CustomException(ErrorCode.ACCESS_DENIED);
+		}
+
+		user.updateRole(requestDto.role());
+	}
+
+	@Transactional
+	public void deleteUser(String username, User loginUser) {
+		checkPermission(username, loginUser);
+		User user = findById(username);
+
+		user.softDelete(loginUser.getUsername());
+	}
+
+	// 공통 권한 체크 메서드
+	private void checkPermission(String username, User loginUser) {
+		if (loginUser.getRole() == UserRole.MASTER) {
+			return; // 관리자면 통과
+		}
+		if (!loginUser.getUsername().equals(username)) {
+			throw new CustomException(ErrorCode.ACCESS_DENIED); // 본인이 아니면 거부
+		}
+	}
+
+	private User findById(String username) {
+		return userRepository.findById(username)
+			.orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+	}
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -14,5 +14,5 @@ spring.datasource.driver-class-name=org.postgresql.Driver
 
 # JWT
 jwt.secret=${JWT_SECRET}
-jwt.access-expiration.min=${JWT_ACCESS_TOKEN_EXP_MIN}
+jwt.access-expiration-min=${JWT_ACCESS_TOKEN_EXP_MIN}
 jwt.refresh-expiration-days=${JWT_REFRESH_TOKEN_EXP_DAYS}

--- a/src/test/java/com/sparta/deliveryorderplatform/user/controller/UserControllerTest.java
+++ b/src/test/java/com/sparta/deliveryorderplatform/user/controller/UserControllerTest.java
@@ -116,9 +116,23 @@ class UserControllerTest {
 	}
 
 	@Test
-	@DisplayName("사용자 상세 조회 실패 - CUSTOMER 권한으로 요청 시 403을 반환한다")
-	void getUser_customer_returns403() throws Exception {
+	@DisplayName("사용자 상세 조회 성공 - CUSTOMER가 본인을 조회하면 200을 반환한다")
+	void getUser_customer_self_returns200() throws Exception {
+		given(userService.getUser(any(), any())).willReturn(sampleResponse());
+
 		mockMvc.perform(get("/api/v1/users/user1234")
+				.with(authentication(customerAuth())))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.data.username").value("user1234"));
+	}
+
+	@Test
+	@DisplayName("사용자 상세 조회 실패 - CUSTOMER가 타인을 조회하면 403을 반환한다")
+	void getUser_customer_other_returns403() throws Exception {
+		given(userService.getUser(any(), any()))
+			.willThrow(new CustomException(ErrorCode.ACCESS_DENIED));
+
+		mockMvc.perform(get("/api/v1/users/other999")
 				.with(authentication(customerAuth())))
 			.andExpect(status().isForbidden());
 	}

--- a/src/test/java/com/sparta/deliveryorderplatform/user/controller/UserControllerTest.java
+++ b/src/test/java/com/sparta/deliveryorderplatform/user/controller/UserControllerTest.java
@@ -1,0 +1,275 @@
+package com.sparta.deliveryorderplatform.user.controller;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.willThrow;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.authentication;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.time.LocalDateTime;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.domain.Page;
+import org.springframework.http.MediaType;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.test.web.servlet.MockMvc;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.sparta.deliveryorderplatform.auth.jwt.JwtAuthenticationEntryPoint;
+import com.sparta.deliveryorderplatform.auth.jwt.JwtTokenProvider;
+import com.sparta.deliveryorderplatform.global.config.SecurityConfig;
+import com.sparta.deliveryorderplatform.global.exception.CustomException;
+import com.sparta.deliveryorderplatform.global.exception.ErrorCode;
+import com.sparta.deliveryorderplatform.user.dto.PasswordChangeRequestDto;
+import com.sparta.deliveryorderplatform.user.dto.UserResponseDto;
+import com.sparta.deliveryorderplatform.user.dto.UserRoleUpdateRequestDto;
+import com.sparta.deliveryorderplatform.user.dto.UserUpdateRequestDto;
+import com.sparta.deliveryorderplatform.user.entity.User;
+import com.sparta.deliveryorderplatform.user.entity.UserRole;
+import com.sparta.deliveryorderplatform.user.security.UserDetailsImpl;
+import com.sparta.deliveryorderplatform.user.service.UserService;
+
+@WebMvcTest(UserController.class)
+@Import({SecurityConfig.class, JwtAuthenticationEntryPoint.class})
+class UserControllerTest {
+
+	@Autowired MockMvc mockMvc;
+	@Autowired ObjectMapper objectMapper;
+
+	@MockBean UserService userService;
+	@MockBean JwtTokenProvider jwtTokenProvider;
+	@MockBean org.springframework.security.core.userdetails.UserDetailsService userDetailsService;
+
+	private Authentication authOf(User user) {
+		UserDetailsImpl userDetails = new UserDetailsImpl(user);
+		return new UsernamePasswordAuthenticationToken(userDetails, null, userDetails.getAuthorities());
+	}
+
+	private Authentication masterAuth() {
+		return authOf(User.createUser("master1", "관리자", "master@example.com", "encoded", UserRole.MASTER));
+	}
+
+	private Authentication customerAuth() {
+		return authOf(User.createUser("user1234", "닉네임", "test@example.com", "encoded", UserRole.CUSTOMER));
+	}
+
+	private UserResponseDto sampleResponse() {
+		return new UserResponseDto("user1234", "닉네임", "test@example.com", UserRole.CUSTOMER, true, LocalDateTime.now());
+	}
+
+	// ─── GET /api/v1/users ───────────────────────────────────────────────────
+
+	@Test
+	@DisplayName("사용자 목록 조회 성공 - MASTER 권한으로 200을 반환한다")
+	void getUsers_master_returns200() throws Exception {
+		given(userService.getUsers(any(), any())).willReturn(Page.empty());
+
+		mockMvc.perform(get("/api/v1/users")
+				.with(authentication(masterAuth())))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.message").value("SUCCESS"));
+	}
+
+	@Test
+	@DisplayName("사용자 목록 조회 실패 - 미인증 요청 시 401을 반환한다")
+	void getUsers_unauthenticated_returns401() throws Exception {
+		mockMvc.perform(get("/api/v1/users"))
+			.andExpect(status().isUnauthorized());
+	}
+
+	@Test
+	@DisplayName("사용자 목록 조회 실패 - CUSTOMER 권한으로 요청 시 403을 반환한다")
+	void getUsers_customer_returns403() throws Exception {
+		mockMvc.perform(get("/api/v1/users")
+				.with(authentication(customerAuth())))
+			.andExpect(status().isForbidden());
+	}
+
+	// ─── GET /api/v1/users/{username} ────────────────────────────────────────
+
+	@Test
+	@DisplayName("사용자 상세 조회 성공 - MASTER 권한으로 200을 반환한다")
+	void getUser_master_returns200() throws Exception {
+		given(userService.getUser(any(), any())).willReturn(sampleResponse());
+
+		mockMvc.perform(get("/api/v1/users/user1234")
+				.with(authentication(masterAuth())))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.data.username").value("user1234"));
+	}
+
+	@Test
+	@DisplayName("사용자 상세 조회 실패 - 미인증 요청 시 401을 반환한다")
+	void getUser_unauthenticated_returns401() throws Exception {
+		mockMvc.perform(get("/api/v1/users/user1234"))
+			.andExpect(status().isUnauthorized());
+	}
+
+	@Test
+	@DisplayName("사용자 상세 조회 실패 - CUSTOMER 권한으로 요청 시 403을 반환한다")
+	void getUser_customer_returns403() throws Exception {
+		mockMvc.perform(get("/api/v1/users/user1234")
+				.with(authentication(customerAuth())))
+			.andExpect(status().isForbidden());
+	}
+
+	// ─── PUT /api/v1/users/{username} ────────────────────────────────────────
+
+	@Test
+	@DisplayName("사용자 정보 수정 성공 - 인증된 사용자가 200을 반환한다")
+	void updateUser_authenticated_returns200() throws Exception {
+		given(userService.updateUser(any(), any(), any())).willReturn(sampleResponse());
+		UserUpdateRequestDto request = new UserUpdateRequestDto("새닉네임", null, null);
+
+		mockMvc.perform(put("/api/v1/users/user1234")
+				.with(authentication(customerAuth()))
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(objectMapper.writeValueAsString(request)))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.message").value("SUCCESS"));
+	}
+
+	@Test
+	@DisplayName("사용자 정보 수정 실패 - 미인증 요청 시 401을 반환한다")
+	void updateUser_unauthenticated_returns401() throws Exception {
+		UserUpdateRequestDto request = new UserUpdateRequestDto("닉네임", null, null);
+
+		mockMvc.perform(put("/api/v1/users/user1234")
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(objectMapper.writeValueAsString(request)))
+			.andExpect(status().isUnauthorized());
+	}
+
+	@Test
+	@DisplayName("사용자 정보 수정 실패 - 이메일 형식 위반 시 400과 VALIDATION_ERROR 코드를 반환한다")
+	void updateUser_invalidEmail_returns400() throws Exception {
+		UserUpdateRequestDto request = new UserUpdateRequestDto(null, "invalid-email", null);
+
+		mockMvc.perform(put("/api/v1/users/user1234")
+				.with(authentication(customerAuth()))
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(objectMapper.writeValueAsString(request)))
+			.andExpect(status().isBadRequest())
+			.andExpect(jsonPath("$.code").value("VALIDATION_ERROR"));
+	}
+
+	@Test
+	@DisplayName("사용자 정보 수정 실패 - 서비스에서 ACCESS_DENIED 발생 시 403을 반환한다")
+	void updateUser_accessDenied_returns403() throws Exception {
+		willThrow(new CustomException(ErrorCode.ACCESS_DENIED))
+			.given(userService).updateUser(any(), any(), any());
+		UserUpdateRequestDto request = new UserUpdateRequestDto("닉네임", null, null);
+
+		mockMvc.perform(put("/api/v1/users/user1234")
+				.with(authentication(customerAuth()))
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(objectMapper.writeValueAsString(request)))
+			.andExpect(status().isForbidden())
+			.andExpect(jsonPath("$.code").value("ACCESS_DENIED"));
+	}
+
+	// ─── PATCH /api/v1/users/{username} ──────────────────────────────────────
+
+	@Test
+	@DisplayName("사용자 삭제 성공 - 인증된 사용자가 200을 반환한다")
+	void deleteUser_authenticated_returns200() throws Exception {
+		mockMvc.perform(patch("/api/v1/users/user1234")
+				.with(authentication(customerAuth())))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.message").value("SUCCESS"));
+	}
+
+	@Test
+	@DisplayName("사용자 삭제 실패 - 미인증 요청 시 401을 반환한다")
+	void deleteUser_unauthenticated_returns401() throws Exception {
+		mockMvc.perform(patch("/api/v1/users/user1234"))
+			.andExpect(status().isUnauthorized());
+	}
+
+	// ─── PUT /api/v1/users/{username}/role ───────────────────────────────────
+
+	@Test
+	@DisplayName("권한 변경 성공 - MASTER 권한으로 200을 반환한다")
+	void updateUserRole_master_returns200() throws Exception {
+		UserRoleUpdateRequestDto request = new UserRoleUpdateRequestDto(UserRole.OWNER);
+
+		mockMvc.perform(put("/api/v1/users/user1234/role")
+				.with(authentication(masterAuth()))
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(objectMapper.writeValueAsString(request)))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.message").value("SUCCESS"));
+	}
+
+	@Test
+	@DisplayName("권한 변경 실패 - 미인증 요청 시 401을 반환한다")
+	void updateUserRole_unauthenticated_returns401() throws Exception {
+		UserRoleUpdateRequestDto request = new UserRoleUpdateRequestDto(UserRole.OWNER);
+
+		mockMvc.perform(put("/api/v1/users/user1234/role")
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(objectMapper.writeValueAsString(request)))
+			.andExpect(status().isUnauthorized());
+	}
+
+	@Test
+	@DisplayName("권한 변경 실패 - CUSTOMER 권한으로 요청 시 403을 반환한다")
+	void updateUserRole_customer_returns403() throws Exception {
+		UserRoleUpdateRequestDto request = new UserRoleUpdateRequestDto(UserRole.OWNER);
+
+		mockMvc.perform(put("/api/v1/users/user1234/role")
+				.with(authentication(customerAuth()))
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(objectMapper.writeValueAsString(request)))
+			.andExpect(status().isForbidden());
+	}
+
+	// ─── PATCH /api/v1/users/{username}/password ─────────────────────────────
+
+	@Test
+	@DisplayName("비밀번호 변경 성공 - 인증된 사용자가 200을 반환한다")
+	void updatePassword_authenticated_returns200() throws Exception {
+		PasswordChangeRequestDto request = new PasswordChangeRequestDto("CurrentPass1!", "NewPass1@");
+
+		mockMvc.perform(patch("/api/v1/users/user1234/password")
+				.with(authentication(customerAuth()))
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(objectMapper.writeValueAsString(request)))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.message").value("SUCCESS"));
+	}
+
+	@Test
+	@DisplayName("비밀번호 변경 실패 - 미인증 요청 시 401을 반환한다")
+	void updatePassword_unauthenticated_returns401() throws Exception {
+		PasswordChangeRequestDto request = new PasswordChangeRequestDto("CurrentPass1!", "NewPass1@");
+
+		mockMvc.perform(patch("/api/v1/users/user1234/password")
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(objectMapper.writeValueAsString(request)))
+			.andExpect(status().isUnauthorized());
+	}
+
+	@Test
+	@DisplayName("비밀번호 변경 실패 - 현재 비밀번호 미입력 시 400과 VALIDATION_ERROR 코드를 반환한다")
+	void updatePassword_blankPassword_returns400() throws Exception {
+		PasswordChangeRequestDto request = new PasswordChangeRequestDto("", "NewPass1@");
+
+		mockMvc.perform(patch("/api/v1/users/user1234/password")
+				.with(authentication(customerAuth()))
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(objectMapper.writeValueAsString(request)))
+			.andExpect(status().isBadRequest())
+			.andExpect(jsonPath("$.code").value("VALIDATION_ERROR"));
+	}
+}

--- a/src/test/java/com/sparta/deliveryorderplatform/user/service/UserServiceTest.java
+++ b/src/test/java/com/sparta/deliveryorderplatform/user/service/UserServiceTest.java
@@ -1,0 +1,331 @@
+package com.sparta.deliveryorderplatform.user.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+
+import com.sparta.deliveryorderplatform.global.exception.CustomException;
+import com.sparta.deliveryorderplatform.global.exception.ErrorCode;
+import com.sparta.deliveryorderplatform.user.dto.PasswordChangeRequestDto;
+import com.sparta.deliveryorderplatform.user.dto.UserResponseDto;
+import com.sparta.deliveryorderplatform.user.dto.UserRoleUpdateRequestDto;
+import com.sparta.deliveryorderplatform.user.dto.UserSearchCondition;
+import com.sparta.deliveryorderplatform.user.dto.UserUpdateRequestDto;
+import com.sparta.deliveryorderplatform.user.entity.User;
+import com.sparta.deliveryorderplatform.user.entity.UserRole;
+import com.sparta.deliveryorderplatform.user.repository.UserRepository;
+
+@ExtendWith(MockitoExtension.class)
+class UserServiceTest {
+
+	@Mock UserRepository userRepository;
+	@Mock BCryptPasswordEncoder passwordEncoder;
+	@InjectMocks UserService userService;
+
+	private User createCustomer(String username) {
+		return User.createUser(username, "닉네임", username + "@example.com", "encodedPassword", UserRole.CUSTOMER);
+	}
+
+	private User createMaster() {
+		return User.createUser("master1", "관리자", "master@example.com", "encodedPassword", UserRole.MASTER);
+	}
+
+	// ─── getUsers ────────────────────────────────────────────────────────────
+
+	@Test
+	@DisplayName("사용자 목록 조회 성공 - 검색 조건에 맞는 페이징된 결과를 반환한다")
+	void getUsers_success_returnsPageOfUsers() {
+		User user = createCustomer("user1234");
+		given(userRepository.searchUsers(any(), any())).willReturn(new PageImpl<>(List.of(user)));
+
+		Page<UserResponseDto> result = userService.getUsers(
+			new UserSearchCondition(null, null, null),
+			PageRequest.of(0, 10)
+		);
+
+		assertThat(result.getContent()).hasSize(1);
+		assertThat(result.getContent().get(0).username()).isEqualTo("user1234");
+	}
+
+	// ─── getUser ─────────────────────────────────────────────────────────────
+
+	@Test
+	@DisplayName("사용자 상세 조회 성공 - 본인이 조회한다")
+	void getUser_self_returnsUserResponse() {
+		User user = createCustomer("user1234");
+		given(userRepository.findById("user1234")).willReturn(Optional.of(user));
+
+		UserResponseDto result = userService.getUser("user1234", user);
+
+		assertThat(result.username()).isEqualTo("user1234");
+		assertThat(result.role()).isEqualTo(UserRole.CUSTOMER);
+	}
+
+	@Test
+	@DisplayName("사용자 상세 조회 성공 - MASTER가 타인을 조회한다")
+	void getUser_master_returnsUserResponse() {
+		User master = createMaster();
+		User target = createCustomer("user1234");
+		given(userRepository.findById("user1234")).willReturn(Optional.of(target));
+
+		UserResponseDto result = userService.getUser("user1234", master);
+
+		assertThat(result.username()).isEqualTo("user1234");
+	}
+
+	@Test
+	@DisplayName("사용자 상세 조회 실패 - 타인 조회 시 ACCESS_DENIED 예외 발생")
+	void getUser_otherUser_throwsAccessDenied() {
+		User other = createCustomer("other999");
+
+		assertThatThrownBy(() -> userService.getUser("user1234", other))
+			.isInstanceOf(CustomException.class)
+			.extracting("errorCode").isEqualTo(ErrorCode.ACCESS_DENIED);
+	}
+
+	@Test
+	@DisplayName("사용자 상세 조회 실패 - 존재하지 않는 사용자 시 USER_NOT_FOUND 예외 발생")
+	void getUser_notFound_throwsUserNotFound() {
+		User user = createCustomer("user1234");
+		given(userRepository.findById("user1234")).willReturn(Optional.empty());
+
+		assertThatThrownBy(() -> userService.getUser("user1234", user))
+			.isInstanceOf(CustomException.class)
+			.extracting("errorCode").isEqualTo(ErrorCode.USER_NOT_FOUND);
+	}
+
+	// ─── updateUser ──────────────────────────────────────────────────────────
+
+	@Test
+	@DisplayName("사용자 정보 수정 성공 - 본인이 닉네임을 수정한다")
+	void updateUser_self_returnsUpdatedUser() {
+		User user = createCustomer("user1234");
+		given(userRepository.findById("user1234")).willReturn(Optional.of(user));
+
+		UserResponseDto result = userService.updateUser(
+			"user1234", new UserUpdateRequestDto("새닉네임", null, null), user
+		);
+
+		assertThat(result.nickname()).isEqualTo("새닉네임");
+	}
+
+	@Test
+	@DisplayName("사용자 정보 수정 성공 - MASTER가 타인의 정보를 수정한다")
+	void updateUser_master_returnsUpdatedUser() {
+		User master = createMaster();
+		User target = createCustomer("user1234");
+		given(userRepository.findById("user1234")).willReturn(Optional.of(target));
+
+		UserResponseDto result = userService.updateUser(
+			"user1234", new UserUpdateRequestDto("새닉네임", null, null), master
+		);
+
+		assertThat(result.nickname()).isEqualTo("새닉네임");
+	}
+
+	@Test
+	@DisplayName("사용자 정보 수정 실패 - 타인 수정 시 ACCESS_DENIED 예외 발생")
+	void updateUser_otherUser_throwsAccessDenied() {
+		User other = createCustomer("other999");
+
+		assertThatThrownBy(() -> userService.updateUser(
+			"user1234", new UserUpdateRequestDto("닉네임", null, null), other
+		))
+			.isInstanceOf(CustomException.class)
+			.extracting("errorCode").isEqualTo(ErrorCode.ACCESS_DENIED);
+	}
+
+	@Test
+	@DisplayName("사용자 정보 수정 실패 - 존재하지 않는 사용자 시 USER_NOT_FOUND 예외 발생")
+	void updateUser_notFound_throwsUserNotFound() {
+		User user = createCustomer("user1234");
+		given(userRepository.findById("user1234")).willReturn(Optional.empty());
+
+		assertThatThrownBy(() -> userService.updateUser(
+			"user1234", new UserUpdateRequestDto("닉네임", null, null), user
+		))
+			.isInstanceOf(CustomException.class)
+			.extracting("errorCode").isEqualTo(ErrorCode.USER_NOT_FOUND);
+	}
+
+	// ─── updatePassword ──────────────────────────────────────────────────────
+
+	@Test
+	@DisplayName("비밀번호 변경 성공 - 본인이 현재 비밀번호를 맞게 입력한다")
+	void updatePassword_self_success() {
+		User user = createCustomer("user1234");
+		given(userRepository.findById("user1234")).willReturn(Optional.of(user));
+		given(passwordEncoder.matches("CurrentPass1!", "encodedPassword")).willReturn(true);
+
+		assertThatCode(() -> userService.updatePassword(
+			"user1234", new PasswordChangeRequestDto("CurrentPass1!", "NewPass1@"), user
+		)).doesNotThrowAnyException();
+	}
+
+	@Test
+	@DisplayName("비밀번호 변경 실패 - 타인이 변경 시도 시 ACCESS_DENIED 예외 발생")
+	void updatePassword_otherUser_throwsAccessDenied() {
+		User other = createCustomer("other999");
+
+		assertThatThrownBy(() -> userService.updatePassword(
+			"user1234", new PasswordChangeRequestDto("CurrentPass1!", "NewPass1@"), other
+		))
+			.isInstanceOf(CustomException.class)
+			.extracting("errorCode").isEqualTo(ErrorCode.ACCESS_DENIED);
+	}
+
+	@Test
+	@DisplayName("비밀번호 변경 실패 - MASTER도 타인 비밀번호 변경 불가 (ACCESS_DENIED 예외 발생)")
+	void updatePassword_master_throwsAccessDenied() {
+		User master = createMaster();
+
+		assertThatThrownBy(() -> userService.updatePassword(
+			"user1234", new PasswordChangeRequestDto("CurrentPass1!", "NewPass1@"), master
+		))
+			.isInstanceOf(CustomException.class)
+			.extracting("errorCode").isEqualTo(ErrorCode.ACCESS_DENIED);
+	}
+
+	@Test
+	@DisplayName("비밀번호 변경 실패 - 현재 비밀번호 불일치 시 INVALID_PASSWORD 예외 발생")
+	void updatePassword_wrongCurrentPassword_throwsInvalidPassword() {
+		User user = createCustomer("user1234");
+		given(userRepository.findById("user1234")).willReturn(Optional.of(user));
+		given(passwordEncoder.matches("WrongPass1!", "encodedPassword")).willReturn(false);
+
+		assertThatThrownBy(() -> userService.updatePassword(
+			"user1234", new PasswordChangeRequestDto("WrongPass1!", "NewPass1@"), user
+		))
+			.isInstanceOf(CustomException.class)
+			.extracting("errorCode").isEqualTo(ErrorCode.INVALID_PASSWORD);
+	}
+
+	@Test
+	@DisplayName("비밀번호 변경 실패 - 존재하지 않는 사용자 시 USER_NOT_FOUND 예외 발생")
+	void updatePassword_notFound_throwsUserNotFound() {
+		User user = createCustomer("user1234");
+		given(userRepository.findById("user1234")).willReturn(Optional.empty());
+
+		assertThatThrownBy(() -> userService.updatePassword(
+			"user1234", new PasswordChangeRequestDto("CurrentPass1!", "NewPass1@"), user
+		))
+			.isInstanceOf(CustomException.class)
+			.extracting("errorCode").isEqualTo(ErrorCode.USER_NOT_FOUND);
+	}
+
+	// ─── updateUserRole ──────────────────────────────────────────────────────
+
+	@Test
+	@DisplayName("권한 변경 성공 - MASTER가 타인의 권한을 변경한다")
+	void updateUserRole_master_success() {
+		User master = createMaster();
+		User target = createCustomer("user1234");
+		given(userRepository.findById("user1234")).willReturn(Optional.of(target));
+
+		userService.updateUserRole("user1234", new UserRoleUpdateRequestDto(UserRole.OWNER), master);
+
+		assertThat(target.getRole()).isEqualTo(UserRole.OWNER);
+	}
+
+	@Test
+	@DisplayName("권한 변경 실패 - CUSTOMER가 시도 시 ACCESS_DENIED 예외 발생")
+	void updateUserRole_customer_throwsAccessDenied() {
+		User customer = createCustomer("user1234");
+
+		assertThatThrownBy(() -> userService.updateUserRole(
+			"other999", new UserRoleUpdateRequestDto(UserRole.OWNER), customer
+		))
+			.isInstanceOf(CustomException.class)
+			.extracting("errorCode").isEqualTo(ErrorCode.ACCESS_DENIED);
+	}
+
+	@Test
+	@DisplayName("권한 변경 실패 - MASTER가 자기 자신 권한 변경 시도 시 ACCESS_DENIED 예외 발생")
+	void updateUserRole_masterSelf_throwsAccessDenied() {
+		User master = createMaster();
+		given(userRepository.findById("master1")).willReturn(Optional.of(master));
+
+		assertThatThrownBy(() -> userService.updateUserRole(
+			"master1", new UserRoleUpdateRequestDto(UserRole.CUSTOMER), master
+		))
+			.isInstanceOf(CustomException.class)
+			.extracting("errorCode").isEqualTo(ErrorCode.ACCESS_DENIED);
+	}
+
+	@Test
+	@DisplayName("권한 변경 실패 - 존재하지 않는 사용자 시 USER_NOT_FOUND 예외 발생")
+	void updateUserRole_notFound_throwsUserNotFound() {
+		User master = createMaster();
+		given(userRepository.findById("user1234")).willReturn(Optional.empty());
+
+		assertThatThrownBy(() -> userService.updateUserRole(
+			"user1234", new UserRoleUpdateRequestDto(UserRole.OWNER), master
+		))
+			.isInstanceOf(CustomException.class)
+			.extracting("errorCode").isEqualTo(ErrorCode.USER_NOT_FOUND);
+	}
+
+	// ─── deleteUser ──────────────────────────────────────────────────────────
+
+	@Test
+	@DisplayName("사용자 삭제 성공 - 본인이 소프트 삭제되고 deletedAt이 설정된다")
+	void deleteUser_self_softDeletesUser() {
+		User user = createCustomer("user1234");
+		given(userRepository.findById("user1234")).willReturn(Optional.of(user));
+
+		userService.deleteUser("user1234", user);
+
+		assertThat(user.getDeletedAt()).isNotNull();
+		assertThat(user.getDeletedBy()).isEqualTo("user1234");
+	}
+
+	@Test
+	@DisplayName("사용자 삭제 성공 - MASTER가 타인을 소프트 삭제하고 deletedBy에 MASTER 아이디가 설정된다")
+	void deleteUser_master_softDeletesUser() {
+		User master = createMaster();
+		User target = createCustomer("user1234");
+		given(userRepository.findById("user1234")).willReturn(Optional.of(target));
+
+		userService.deleteUser("user1234", master);
+
+		assertThat(target.getDeletedAt()).isNotNull();
+		assertThat(target.getDeletedBy()).isEqualTo("master1");
+	}
+
+	@Test
+	@DisplayName("사용자 삭제 실패 - 타인 삭제 시도 시 ACCESS_DENIED 예외 발생")
+	void deleteUser_otherUser_throwsAccessDenied() {
+		User other = createCustomer("other999");
+
+		assertThatThrownBy(() -> userService.deleteUser("user1234", other))
+			.isInstanceOf(CustomException.class)
+			.extracting("errorCode").isEqualTo(ErrorCode.ACCESS_DENIED);
+	}
+
+	@Test
+	@DisplayName("사용자 삭제 실패 - 존재하지 않는 사용자 시 USER_NOT_FOUND 예외 발생")
+	void deleteUser_notFound_throwsUserNotFound() {
+		User user = createCustomer("user1234");
+		given(userRepository.findById("user1234")).willReturn(Optional.empty());
+
+		assertThatThrownBy(() -> userService.deleteUser("user1234", user))
+			.isInstanceOf(CustomException.class)
+			.extracting("errorCode").isEqualTo(ErrorCode.USER_NOT_FOUND);
+	}
+}


### PR DESCRIPTION
## ✨ 작업 내용
> 사용자 관리 API 구현 (목록 조회 / 상세 조회 / 정보 수정 / 삭제 / 권한 변경)
  - 목록 조회는 QueryDSL을 이용한 동적 검색(username, nickname, role) + 페이징 지원

> Spring Security 사용자 인증 구현
- UserDetailsImpl — UserDetails 구현체, User 엔티티를 감싸서 Spring Security가 인식할 수 있는 인증 객체로 변환
- UserDetailsServiceImpl — UserDetailsService 구현체, username으로 DB에서 사용자를 조회해 UserDetailsImpl 반환

> Security 개선
- JwtAuthenticationFilter가 토큰에서 권한을 직접 파싱하던 방식 → UserDetailsService를 통해 DB에서 UserDetailsImpl을
  로드하는 방식으로 변경 (@AuthenticationPrincipal UserDetailsImpl 정상 동작)
- @EnableMethodSecurity 활성화 → 컨트롤러에서 @PreAuthorize 사용 가능

## 📸 스크린샷(선택)
> 스크린샷이 필요한 작업이면 스크린샷을 첨부해주세요

## ✅ 테스트
- [x] 정상 동작 확인
  - 권한별 접근 제어, 예외 케이스(ACCESS_DENIED, USER_NOT_FOUND 등), 소프트 삭제 검증 포함

## 📚 레퍼런스 (또는 새로 알게 된 내용) 혹은 궁금한 사항들
> 참고할 사항이 있다면 적어주세요