### PR TITLE
Feature/address

### DIFF
--- a/src/main/java/com/sparta/deliveryorderplatform/address/controller/AddressController.java
+++ b/src/main/java/com/sparta/deliveryorderplatform/address/controller/AddressController.java
@@ -1,0 +1,100 @@
+package com.sparta.deliveryorderplatform.address.controller;
+
+import java.util.UUID;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.sparta.deliveryorderplatform.address.dto.AddressCreateRequest;
+import com.sparta.deliveryorderplatform.address.dto.AddressResponse;
+import com.sparta.deliveryorderplatform.address.dto.AddressUpdateRequest;
+import com.sparta.deliveryorderplatform.address.service.AddressService;
+import com.sparta.deliveryorderplatform.global.common.ApiResponse;
+import com.sparta.deliveryorderplatform.global.common.PageResponse;
+import com.sparta.deliveryorderplatform.user.security.UserDetailsImpl;
+
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequestMapping("/api/v1/addresses")
+@RequiredArgsConstructor
+public class AddressController {
+
+	private final AddressService addressService;
+
+	// 배송지 생성
+	@PostMapping
+	public ResponseEntity<ApiResponse<AddressResponse>> createAddress(
+		@RequestBody @Valid AddressCreateRequest request,
+		@AuthenticationPrincipal UserDetailsImpl userDetails
+	) {
+		AddressResponse response = addressService.createAddress(request, userDetails.getUser());
+		return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.success(response));
+	}
+
+	// 배송지 목록 조회
+	@GetMapping
+	public ResponseEntity<ApiResponse<PageResponse<AddressResponse>>> getAddressList(
+		@PageableDefault(size = 10, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable,
+		@AuthenticationPrincipal UserDetailsImpl userDetails) {
+
+		Page<AddressResponse> responses = addressService.getAddresses(userDetails.getUser(), pageable);
+		return ResponseEntity.ok(ApiResponse.success(PageResponse.of(responses)));
+	}
+
+	// 배송지 상세 조회
+	@GetMapping("/{addressId}")
+	public ResponseEntity<ApiResponse<AddressResponse>> getAddressDetail(
+		@PathVariable UUID addressId,
+		@AuthenticationPrincipal UserDetailsImpl userDetails) {
+
+		AddressResponse response = addressService.getAddress(addressId, userDetails.getUser());
+		return ResponseEntity.ok(ApiResponse.success(response));
+	}
+
+	// 배송지 수정
+	@PutMapping("/{addressId}")
+	public ResponseEntity<ApiResponse<AddressResponse>> updateAddress(
+		@PathVariable UUID addressId,
+		@RequestBody @Valid AddressUpdateRequest request,
+		@AuthenticationPrincipal UserDetailsImpl userDetails) {
+
+		AddressResponse response = addressService.updateAddress(addressId, request, userDetails.getUser());
+		return ResponseEntity.ok(ApiResponse.success(response));
+	}
+
+	// 배송지 삭제
+	@DeleteMapping("/{addressId}")
+	public ResponseEntity<ApiResponse<Void>> deleteAddress(
+		@PathVariable UUID addressId,
+		@AuthenticationPrincipal UserDetailsImpl userDetails
+	) {
+		addressService.deleteAddress(addressId, userDetails.getUser());
+		return ResponseEntity.ok(ApiResponse.success());
+	}
+
+	// 기본 배송지 설정
+	@PatchMapping("/{addressId}/default")
+	public ResponseEntity<ApiResponse<Void>> setDefaultAddress(
+		@PathVariable UUID addressId,
+		@AuthenticationPrincipal UserDetailsImpl userDetails
+	) {
+		addressService.setDefaultAddress(addressId, userDetails.getUser());
+		return ResponseEntity.ok(ApiResponse.success());
+	}
+}

--- a/src/main/java/com/sparta/deliveryorderplatform/address/dto/AddressCreateRequest.java
+++ b/src/main/java/com/sparta/deliveryorderplatform/address/dto/AddressCreateRequest.java
@@ -1,0 +1,12 @@
+package com.sparta.deliveryorderplatform.address.dto;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record AddressCreateRequest(
+	String alias,
+	@NotBlank
+	String address,
+	String detail,
+	String zipCode,
+	boolean isDefault
+) {}

--- a/src/main/java/com/sparta/deliveryorderplatform/address/dto/AddressResponse.java
+++ b/src/main/java/com/sparta/deliveryorderplatform/address/dto/AddressResponse.java
@@ -1,0 +1,32 @@
+package com.sparta.deliveryorderplatform.address.dto;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+import com.sparta.deliveryorderplatform.address.entity.Address;
+
+import lombok.Builder;
+
+@Builder
+public record AddressResponse(
+    UUID id,
+    String alias,
+    String address,
+    String detail,
+    String zipCode,
+    Boolean isDefault,
+    LocalDateTime createdAt
+) {
+    // 엔티티를 DTO로 변환하는 정적 메서드
+    public static AddressResponse from(Address address) {
+        return AddressResponse.builder()
+                .id(address.getId())
+                .alias(address.getAlias())
+                .address(address.getAddress())
+                .detail(address.getDetail())
+                .zipCode(address.getZipCode())
+                .isDefault(address.isDefault())
+                .createdAt(address.getCreatedAt())
+                .build();
+    }
+}

--- a/src/main/java/com/sparta/deliveryorderplatform/address/dto/AddressUpdateRequest.java
+++ b/src/main/java/com/sparta/deliveryorderplatform/address/dto/AddressUpdateRequest.java
@@ -1,0 +1,12 @@
+package com.sparta.deliveryorderplatform.address.dto;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record AddressUpdateRequest(
+    String alias,
+    @NotBlank(message = "주소는 필수 입력 사항입니다.")
+    String address,
+    String detail,
+    String zipCode,
+    boolean isDefault
+) {}

--- a/src/main/java/com/sparta/deliveryorderplatform/address/entity/Address.java
+++ b/src/main/java/com/sparta/deliveryorderplatform/address/entity/Address.java
@@ -45,14 +45,15 @@ public class Address extends BaseAuditEntity {
 	@Column(name = "zip_code")
 	private String zipCode;
 
-	@Column(name = "is_default")
-	private Boolean isDefault;
+	@Builder.Default
+	@Column(name = "is_default", nullable = false)
+	private boolean isDefault = false;
 
 	@ManyToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "user_id")
 	private User user;
 
-	public static Address createAddress(String alias, String address, String detail, String zipCode, Boolean isDefault, User user) {
+	public static Address createAddress(String alias, String address, String detail, String zipCode, boolean isDefault, User user) {
 		if (address == null || address.isBlank()) throw new CustomException(ErrorCode.VALIDATION_ERROR);
 		if (user == null) throw new CustomException(ErrorCode.USER_NOT_FOUND);
 
@@ -61,12 +62,12 @@ public class Address extends BaseAuditEntity {
 			.address(address)
 			.detail(detail)
 			.zipCode(zipCode)
-			.isDefault(isDefault != null && isDefault)
+			.isDefault(isDefault)
 			.user(user)
 			.build();
 	}
 
-	public void updateAddress(String alias, String address, String detail, String zipCode, Boolean isDefault) {
+	public void updateAddress(String alias, String address, String detail, String zipCode, boolean isDefault) {
 		if (address == null || address.isBlank()) throw new CustomException(ErrorCode.VALIDATION_ERROR);
 
 		this.alias = alias;

--- a/src/main/java/com/sparta/deliveryorderplatform/address/entity/Address.java
+++ b/src/main/java/com/sparta/deliveryorderplatform/address/entity/Address.java
@@ -1,0 +1,86 @@
+package com.sparta.deliveryorderplatform.address.entity;
+
+import java.util.UUID;
+
+import com.sparta.deliveryorderplatform.global.entity.BaseAuditEntity;
+import com.sparta.deliveryorderplatform.global.exception.CustomException;
+import com.sparta.deliveryorderplatform.global.exception.ErrorCode;
+import com.sparta.deliveryorderplatform.user.entity.User;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "p_address")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+@Builder(access = AccessLevel.PRIVATE)
+public class Address extends BaseAuditEntity {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.UUID)
+	@Column(name = "address_id")
+	private UUID id;
+
+	private String alias; // 별칭(집, 회사 등)
+
+	@Column(nullable = false)
+	private String address; // 주소
+
+	private String detail; // 상세 주소
+
+	@Column(name = "zip_code")
+	private String zipCode;
+
+	@Column(name = "is_default")
+	private Boolean isDefault;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "user_id")
+	private User user;
+
+	public static Address createAddress(String alias, String address, String detail, String zipCode, Boolean isDefault, User user) {
+		if (address == null || address.isBlank()) throw new CustomException(ErrorCode.VALIDATION_ERROR);
+		if (user == null) throw new CustomException(ErrorCode.USER_NOT_FOUND);
+
+		return Address.builder()
+			.alias(alias)
+			.address(address)
+			.detail(detail)
+			.zipCode(zipCode)
+			.isDefault(isDefault != null && isDefault)
+			.user(user)
+			.build();
+	}
+
+	public void updateAddress(String alias, String address, String detail, String zipCode, Boolean isDefault) {
+		if (address == null || address.isBlank()) throw new CustomException(ErrorCode.VALIDATION_ERROR);
+
+		this.alias = alias;
+		this.address = address;
+		this.detail = detail;
+		this.zipCode = zipCode;
+		this.isDefault = isDefault;
+	}
+
+	public void markAsDefault() {
+		this.isDefault = true;
+	}
+
+	public void unmarkAsDefault() {
+		this.isDefault = false;
+	}
+}

--- a/src/main/java/com/sparta/deliveryorderplatform/address/repository/AddressRepository.java
+++ b/src/main/java/com/sparta/deliveryorderplatform/address/repository/AddressRepository.java
@@ -13,5 +13,5 @@ import com.sparta.deliveryorderplatform.user.entity.User;
 public interface AddressRepository extends JpaRepository<Address, UUID> {
 	Page<Address> findByUserAndDeletedAtIsNull(User user, Pageable pageable);
 	Page<Address> findAll(Pageable pageable);
-	Optional<Address> findByUserAndIsDefaultTrue (User user);
+	Optional<Address> findByUserAndIsDefaultTrueAndDeletedAtIsNull (User user);
 }

--- a/src/main/java/com/sparta/deliveryorderplatform/address/repository/AddressRepository.java
+++ b/src/main/java/com/sparta/deliveryorderplatform/address/repository/AddressRepository.java
@@ -11,7 +11,7 @@ import com.sparta.deliveryorderplatform.address.entity.Address;
 import com.sparta.deliveryorderplatform.user.entity.User;
 
 public interface AddressRepository extends JpaRepository<Address, UUID> {
-	Page<Address> findByUser(User user, Pageable pageable);
+	Page<Address> findByUserAndDeletedAtIsNull(User user, Pageable pageable);
 	Page<Address> findAll(Pageable pageable);
 	Optional<Address> findByUserAndIsDefaultTrue (User user);
 }

--- a/src/main/java/com/sparta/deliveryorderplatform/address/repository/AddressRepository.java
+++ b/src/main/java/com/sparta/deliveryorderplatform/address/repository/AddressRepository.java
@@ -1,0 +1,17 @@
+package com.sparta.deliveryorderplatform.address.repository;
+
+import java.util.Optional;
+import java.util.UUID;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.sparta.deliveryorderplatform.address.entity.Address;
+import com.sparta.deliveryorderplatform.user.entity.User;
+
+public interface AddressRepository extends JpaRepository<Address, UUID> {
+	Page<Address> findByUser(User user, Pageable pageable);
+	Page<Address> findAll(Pageable pageable);
+	Optional<Address> findByUserAndIsDefaultTrue (User user);
+}

--- a/src/main/java/com/sparta/deliveryorderplatform/address/service/AddressService.java
+++ b/src/main/java/com/sparta/deliveryorderplatform/address/service/AddressService.java
@@ -102,6 +102,8 @@ public class AddressService {
 
 		checkPermission(address, user);
 
+		if (address.isDefault()) return;
+
 		disableDefaultAddress(user);
 
 		address.markAsDefault();
@@ -123,7 +125,7 @@ public class AddressService {
 	}
 
 	private void disableDefaultAddress(User user) {
-		addressRepository.findByUserAndIsDefaultTrue(user)
+		addressRepository.findByUserAndIsDefaultTrueAndDeletedAtIsNull(user)
 			.ifPresent(Address::unmarkAsDefault);
 	}
 }

--- a/src/main/java/com/sparta/deliveryorderplatform/address/service/AddressService.java
+++ b/src/main/java/com/sparta/deliveryorderplatform/address/service/AddressService.java
@@ -50,7 +50,7 @@ public class AddressService {
 		if (user.getRole() == UserRole.MASTER) {
 			addressPage = addressRepository.findAll(pageable);
 		} else {
-			addressPage = addressRepository.findByUser(user, pageable);
+			addressPage = addressRepository.findByUserAndDeletedAtIsNull(user, pageable);
 		}
 
 		return addressPage.map(AddressResponse::from);

--- a/src/main/java/com/sparta/deliveryorderplatform/address/service/AddressService.java
+++ b/src/main/java/com/sparta/deliveryorderplatform/address/service/AddressService.java
@@ -1,0 +1,129 @@
+package com.sparta.deliveryorderplatform.address.service;
+
+import java.util.UUID;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.sparta.deliveryorderplatform.address.dto.AddressCreateRequest;
+import com.sparta.deliveryorderplatform.address.dto.AddressResponse;
+import com.sparta.deliveryorderplatform.address.dto.AddressUpdateRequest;
+import com.sparta.deliveryorderplatform.address.entity.Address;
+import com.sparta.deliveryorderplatform.address.repository.AddressRepository;
+import com.sparta.deliveryorderplatform.global.exception.CustomException;
+import com.sparta.deliveryorderplatform.global.exception.ErrorCode;
+import com.sparta.deliveryorderplatform.user.entity.User;
+import com.sparta.deliveryorderplatform.user.entity.UserRole;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class AddressService {
+
+	private final AddressRepository addressRepository;
+
+	@Transactional
+	public AddressResponse createAddress(AddressCreateRequest request, User user) {
+		if (request.isDefault()) {
+			disableDefaultAddress(user);
+		}
+
+		Address address = Address.createAddress(
+			request.alias(),
+			request.address(),
+			request.detail(),
+			request.zipCode(),
+			request.isDefault(),
+			user
+		);
+
+		return AddressResponse.from(addressRepository.save(address));
+	}
+
+	public Page<AddressResponse> getAddresses(User user, Pageable pageable) {
+		Page<Address> addressPage;
+
+		if (user.getRole() == UserRole.MASTER) {
+			addressPage = addressRepository.findAll(pageable);
+		} else {
+			addressPage = addressRepository.findByUser(user, pageable);
+		}
+
+		return addressPage.map(AddressResponse::from);
+	}
+
+	public AddressResponse getAddress(UUID addressID, User user) {
+		Address address = findById(addressID);
+
+		checkPermission(address, user);
+
+		return AddressResponse.from(address);
+	}
+
+	@Transactional
+	public AddressResponse updateAddress(UUID addressId, AddressUpdateRequest request, User user) {
+		Address address = findById(addressId);
+
+		checkPermission(address, user);
+
+		if (request.isDefault() && !address.isDefault()) {
+			disableDefaultAddress(user);
+		}
+
+		address.updateAddress(
+			request.alias(),
+			request.address(),
+			request.detail(),
+			request.zipCode(),
+			request.isDefault()
+		);
+
+		return AddressResponse.from(address);
+	}
+
+	@Transactional
+	public void deleteAddress(UUID addressId, User user) {
+		Address address = findById(addressId);
+
+		if (user.getRole() != UserRole.MASTER && !address.getUser().getUsername().equals(user.getUsername())) {
+			throw new CustomException(ErrorCode.ACCESS_DENIED);
+		}
+
+		address.softDelete(user.getUsername());
+	}
+
+	@Transactional
+	public void setDefaultAddress(UUID addressId, User user) {
+		Address address = findById(addressId);
+
+		checkPermission(address, user);
+
+		disableDefaultAddress(user);
+
+		address.markAsDefault();
+	}
+
+	private Address findById(UUID addressId) {
+		return addressRepository.findById(addressId)
+			.orElseThrow(() -> new CustomException(ErrorCode.ADDRESS_NOT_FOUND));
+	}
+
+	private void checkPermission(Address address, User user) {
+		if (user.getRole() == UserRole.MASTER) {
+			return;
+		}
+
+		if (!address.getUser().getUsername().equals(user.getUsername())) {
+			throw new CustomException(ErrorCode.ACCESS_DENIED);
+		}
+	}
+
+	private void disableDefaultAddress(User user) {
+		addressRepository.findByUserAndIsDefaultTrue(user)
+			.ifPresent(Address::unmarkAsDefault);
+	}
+}

--- a/src/main/java/com/sparta/deliveryorderplatform/global/exception/ErrorCode.java
+++ b/src/main/java/com/sparta/deliveryorderplatform/global/exception/ErrorCode.java
@@ -48,7 +48,10 @@ public enum ErrorCode {
 	EXPIRED_TOKEN(401, "EXPIRED_TOKEN", "만료된 토큰입니다."),
 	UNSUPPORTED_TOKEN(401, "UNSUPPORTED_TOKEN", "지원되지 않는 토큰입니다."),
 	WRONG_TOKEN(401, "WRONG_TOKEN", "잘못된 토큰 서명입니다."),
-	TOKEN_NOT_FOUND(401, "TOKEN_NOT_FOUND", "토큰을 찾을 수 없습니다.");
+	TOKEN_NOT_FOUND(401, "TOKEN_NOT_FOUND", "토큰을 찾을 수 없습니다."),
+
+	// address
+	ADDRESS_NOT_FOUND(401, "ADDRESS_NOT_FOUND", "배송지를 찾을 수 없습니다.");
 
 	private final int status;
 	private final String code;

--- a/src/main/java/com/sparta/deliveryorderplatform/order/entity/Order.java
+++ b/src/main/java/com/sparta/deliveryorderplatform/order/entity/Order.java
@@ -1,9 +1,13 @@
 package com.sparta.deliveryorderplatform.order.entity;
 
+import java.util.UUID;
+
+import com.sparta.deliveryorderplatform.address.entity.Address;
 import com.sparta.deliveryorderplatform.global.entity.BaseAuditEntity;
 import com.sparta.deliveryorderplatform.order.dto.OrderRequestDto;
 import com.sparta.deliveryorderplatform.store.entity.Store;
 import com.sparta.deliveryorderplatform.user.entity.User;
+
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
@@ -16,12 +20,10 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.Lob;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
-import java.util.UUID;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import lombok.Setter;
 
 @Getter
 @Table(name = "p_order")

--- a/src/test/java/com/sparta/deliveryorderplatform/address/controller/AddressControllerTest.java
+++ b/src/test/java/com/sparta/deliveryorderplatform/address/controller/AddressControllerTest.java
@@ -1,0 +1,299 @@
+package com.sparta.deliveryorderplatform.address.controller;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.willThrow;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.authentication;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.domain.Page;
+import org.springframework.http.MediaType;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.test.web.servlet.MockMvc;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.sparta.deliveryorderplatform.address.dto.AddressCreateRequest;
+import com.sparta.deliveryorderplatform.address.dto.AddressResponse;
+import com.sparta.deliveryorderplatform.address.dto.AddressUpdateRequest;
+import com.sparta.deliveryorderplatform.address.service.AddressService;
+import com.sparta.deliveryorderplatform.auth.jwt.JwtAuthenticationEntryPoint;
+import com.sparta.deliveryorderplatform.auth.jwt.JwtTokenProvider;
+import com.sparta.deliveryorderplatform.global.config.SecurityConfig;
+import com.sparta.deliveryorderplatform.global.exception.CustomException;
+import com.sparta.deliveryorderplatform.global.exception.ErrorCode;
+import com.sparta.deliveryorderplatform.user.entity.User;
+import com.sparta.deliveryorderplatform.user.entity.UserRole;
+import com.sparta.deliveryorderplatform.user.security.UserDetailsImpl;
+
+@WebMvcTest(AddressController.class)
+@Import({SecurityConfig.class, JwtAuthenticationEntryPoint.class})
+class AddressControllerTest {
+
+	@Autowired MockMvc mockMvc;
+	@Autowired ObjectMapper objectMapper;
+
+	@MockBean AddressService addressService;
+	@MockBean JwtTokenProvider jwtTokenProvider;
+	@MockBean org.springframework.security.core.userdetails.UserDetailsService userDetailsService;
+
+	private Authentication authOf(User user) {
+		UserDetailsImpl userDetails = new UserDetailsImpl(user);
+		return new UsernamePasswordAuthenticationToken(userDetails, null, userDetails.getAuthorities());
+	}
+
+	private Authentication customerAuth() {
+		return authOf(User.createUser("user1234", "닉네임", "test@example.com", "encoded", UserRole.CUSTOMER));
+	}
+
+	private Authentication masterAuth() {
+		return authOf(User.createUser("master1", "관리자", "master@example.com", "encoded", UserRole.MASTER));
+	}
+
+	private AddressResponse sampleResponse() {
+		return AddressResponse.builder()
+			.id(UUID.randomUUID())
+			.alias("집")
+			.address("서울시 강남구")
+			.detail("101호")
+			.zipCode("06000")
+			.isDefault(false)
+			.createdAt(LocalDateTime.now())
+			.build();
+	}
+
+	// ─── POST /api/v1/addresses ──────────────────────────────────────────────
+
+	@Test
+	@DisplayName("배송지 생성 성공 - 인증된 사용자가 201을 반환한다")
+	void createAddress_authenticated_returns201() throws Exception {
+		given(addressService.createAddress(any(), any())).willReturn(sampleResponse());
+		AddressCreateRequest request = new AddressCreateRequest("집", "서울시 강남구", "101호", "06000", false);
+
+		mockMvc.perform(post("/api/v1/addresses")
+				.with(authentication(customerAuth()))
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(objectMapper.writeValueAsString(request)))
+			.andExpect(status().isCreated())
+			.andExpect(jsonPath("$.message").value("SUCCESS"))
+			.andExpect(jsonPath("$.data.address").value("서울시 강남구"));
+	}
+
+	@Test
+	@DisplayName("배송지 생성 실패 - 미인증 요청 시 401을 반환한다")
+	void createAddress_unauthenticated_returns401() throws Exception {
+		AddressCreateRequest request = new AddressCreateRequest("집", "서울시 강남구", "101호", "06000", false);
+
+		mockMvc.perform(post("/api/v1/addresses")
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(objectMapper.writeValueAsString(request)))
+			.andExpect(status().isUnauthorized());
+	}
+
+	@Test
+	@DisplayName("배송지 생성 실패 - 주소 누락 시 400과 VALIDATION_ERROR 코드를 반환한다")
+	void createAddress_blankAddress_returns400() throws Exception {
+		AddressCreateRequest request = new AddressCreateRequest("집", "", "101호", "06000", false);
+
+		mockMvc.perform(post("/api/v1/addresses")
+				.with(authentication(customerAuth()))
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(objectMapper.writeValueAsString(request)))
+			.andExpect(status().isBadRequest())
+			.andExpect(jsonPath("$.code").value("VALIDATION_ERROR"));
+	}
+
+	// ─── GET /api/v1/addresses ───────────────────────────────────────────────
+
+	@Test
+	@DisplayName("배송지 목록 조회 성공 - 인증된 사용자가 200을 반환한다")
+	void getAddressList_authenticated_returns200() throws Exception {
+		given(addressService.getAddresses(any(), any())).willReturn(Page.empty());
+
+		mockMvc.perform(get("/api/v1/addresses")
+				.with(authentication(customerAuth())))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.message").value("SUCCESS"));
+	}
+
+	@Test
+	@DisplayName("배송지 목록 조회 실패 - 미인증 요청 시 401을 반환한다")
+	void getAddressList_unauthenticated_returns401() throws Exception {
+		mockMvc.perform(get("/api/v1/addresses"))
+			.andExpect(status().isUnauthorized());
+	}
+
+	// ─── GET /api/v1/addresses/{addressId} ──────────────────────────────────
+
+	@Test
+	@DisplayName("배송지 상세 조회 성공 - 인증된 사용자가 200을 반환한다")
+	void getAddressDetail_authenticated_returns200() throws Exception {
+		given(addressService.getAddress(any(), any())).willReturn(sampleResponse());
+
+		mockMvc.perform(get("/api/v1/addresses/{id}", UUID.randomUUID())
+				.with(authentication(customerAuth())))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.data.address").value("서울시 강남구"));
+	}
+
+	@Test
+	@DisplayName("배송지 상세 조회 실패 - 미인증 요청 시 401을 반환한다")
+	void getAddressDetail_unauthenticated_returns401() throws Exception {
+		mockMvc.perform(get("/api/v1/addresses/{id}", UUID.randomUUID()))
+			.andExpect(status().isUnauthorized());
+	}
+
+	@Test
+	@DisplayName("배송지 상세 조회 실패 - 서비스에서 ACCESS_DENIED 발생 시 403을 반환한다")
+	void getAddressDetail_accessDenied_returns403() throws Exception {
+		given(addressService.getAddress(any(), any()))
+			.willThrow(new CustomException(ErrorCode.ACCESS_DENIED));
+
+		mockMvc.perform(get("/api/v1/addresses/{id}", UUID.randomUUID())
+				.with(authentication(customerAuth())))
+			.andExpect(status().isForbidden())
+			.andExpect(jsonPath("$.code").value("ACCESS_DENIED"));
+	}
+
+	@Test
+	@DisplayName("배송지 상세 조회 실패 - 존재하지 않는 배송지 시 401을 반환한다")
+	void getAddressDetail_notFound_returns401() throws Exception {
+		given(addressService.getAddress(any(), any()))
+			.willThrow(new CustomException(ErrorCode.ADDRESS_NOT_FOUND));
+
+		mockMvc.perform(get("/api/v1/addresses/{id}", UUID.randomUUID())
+				.with(authentication(customerAuth())))
+			.andExpect(status().isUnauthorized())
+			.andExpect(jsonPath("$.code").value("ADDRESS_NOT_FOUND"));
+	}
+
+	// ─── PUT /api/v1/addresses/{addressId} ──────────────────────────────────
+
+	@Test
+	@DisplayName("배송지 수정 성공 - 인증된 사용자가 200을 반환한다")
+	void updateAddress_authenticated_returns200() throws Exception {
+		given(addressService.updateAddress(any(), any(), any())).willReturn(sampleResponse());
+		AddressUpdateRequest request = new AddressUpdateRequest("회사", "서울시 종로구", "202호", "03000", false);
+
+		mockMvc.perform(put("/api/v1/addresses/{id}", UUID.randomUUID())
+				.with(authentication(customerAuth()))
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(objectMapper.writeValueAsString(request)))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.message").value("SUCCESS"));
+	}
+
+	@Test
+	@DisplayName("배송지 수정 실패 - 미인증 요청 시 401을 반환한다")
+	void updateAddress_unauthenticated_returns401() throws Exception {
+		AddressUpdateRequest request = new AddressUpdateRequest("회사", "서울시 종로구", "202호", "03000", false);
+
+		mockMvc.perform(put("/api/v1/addresses/{id}", UUID.randomUUID())
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(objectMapper.writeValueAsString(request)))
+			.andExpect(status().isUnauthorized());
+	}
+
+	@Test
+	@DisplayName("배송지 수정 실패 - 주소 누락 시 400과 VALIDATION_ERROR 코드를 반환한다")
+	void updateAddress_blankAddress_returns400() throws Exception {
+		AddressUpdateRequest request = new AddressUpdateRequest("회사", "", "202호", "03000", false);
+
+		mockMvc.perform(put("/api/v1/addresses/{id}", UUID.randomUUID())
+				.with(authentication(customerAuth()))
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(objectMapper.writeValueAsString(request)))
+			.andExpect(status().isBadRequest())
+			.andExpect(jsonPath("$.code").value("VALIDATION_ERROR"));
+	}
+
+	@Test
+	@DisplayName("배송지 수정 실패 - 서비스에서 ACCESS_DENIED 발생 시 403을 반환한다")
+	void updateAddress_accessDenied_returns403() throws Exception {
+		willThrow(new CustomException(ErrorCode.ACCESS_DENIED))
+			.given(addressService).updateAddress(any(), any(), any());
+		AddressUpdateRequest request = new AddressUpdateRequest("회사", "서울시 종로구", "202호", "03000", false);
+
+		mockMvc.perform(put("/api/v1/addresses/{id}", UUID.randomUUID())
+				.with(authentication(customerAuth()))
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(objectMapper.writeValueAsString(request)))
+			.andExpect(status().isForbidden())
+			.andExpect(jsonPath("$.code").value("ACCESS_DENIED"));
+	}
+
+	// ─── DELETE /api/v1/addresses/{addressId} ───────────────────────────────
+
+	@Test
+	@DisplayName("배송지 삭제 성공 - 인증된 사용자가 200을 반환한다")
+	void deleteAddress_authenticated_returns200() throws Exception {
+		mockMvc.perform(delete("/api/v1/addresses/{id}", UUID.randomUUID())
+				.with(authentication(customerAuth())))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.message").value("SUCCESS"));
+	}
+
+	@Test
+	@DisplayName("배송지 삭제 실패 - 미인증 요청 시 401을 반환한다")
+	void deleteAddress_unauthenticated_returns401() throws Exception {
+		mockMvc.perform(delete("/api/v1/addresses/{id}", UUID.randomUUID()))
+			.andExpect(status().isUnauthorized());
+	}
+
+	@Test
+	@DisplayName("배송지 삭제 실패 - 서비스에서 ACCESS_DENIED 발생 시 403을 반환한다")
+	void deleteAddress_accessDenied_returns403() throws Exception {
+		willThrow(new CustomException(ErrorCode.ACCESS_DENIED))
+			.given(addressService).deleteAddress(any(), any());
+
+		mockMvc.perform(delete("/api/v1/addresses/{id}", UUID.randomUUID())
+				.with(authentication(customerAuth())))
+			.andExpect(status().isForbidden())
+			.andExpect(jsonPath("$.code").value("ACCESS_DENIED"));
+	}
+
+	// ─── PATCH /api/v1/addresses/{addressId}/default ────────────────────────
+
+	@Test
+	@DisplayName("기본 배송지 설정 성공 - 인증된 사용자가 200을 반환한다")
+	void setDefaultAddress_authenticated_returns200() throws Exception {
+		mockMvc.perform(patch("/api/v1/addresses/{id}/default", UUID.randomUUID())
+				.with(authentication(customerAuth())))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.message").value("SUCCESS"));
+	}
+
+	@Test
+	@DisplayName("기본 배송지 설정 실패 - 미인증 요청 시 401을 반환한다")
+	void setDefaultAddress_unauthenticated_returns401() throws Exception {
+		mockMvc.perform(patch("/api/v1/addresses/{id}/default", UUID.randomUUID()))
+			.andExpect(status().isUnauthorized());
+	}
+
+	@Test
+	@DisplayName("기본 배송지 설정 실패 - 서비스에서 ACCESS_DENIED 발생 시 403을 반환한다")
+	void setDefaultAddress_accessDenied_returns403() throws Exception {
+		willThrow(new CustomException(ErrorCode.ACCESS_DENIED))
+			.given(addressService).setDefaultAddress(any(), any());
+
+		mockMvc.perform(patch("/api/v1/addresses/{id}/default", UUID.randomUUID())
+				.with(authentication(customerAuth())))
+			.andExpect(status().isForbidden())
+			.andExpect(jsonPath("$.code").value("ACCESS_DENIED"));
+	}
+}

--- a/src/test/java/com/sparta/deliveryorderplatform/address/service/AddressServiceTest.java
+++ b/src/test/java/com/sparta/deliveryorderplatform/address/service/AddressServiceTest.java
@@ -1,0 +1,331 @@
+package com.sparta.deliveryorderplatform.address.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+
+import com.sparta.deliveryorderplatform.address.dto.AddressCreateRequest;
+import com.sparta.deliveryorderplatform.address.dto.AddressResponse;
+import com.sparta.deliveryorderplatform.address.dto.AddressUpdateRequest;
+import com.sparta.deliveryorderplatform.address.entity.Address;
+import com.sparta.deliveryorderplatform.address.repository.AddressRepository;
+import com.sparta.deliveryorderplatform.global.exception.CustomException;
+import com.sparta.deliveryorderplatform.global.exception.ErrorCode;
+import com.sparta.deliveryorderplatform.user.entity.User;
+import com.sparta.deliveryorderplatform.user.entity.UserRole;
+
+@ExtendWith(MockitoExtension.class)
+class AddressServiceTest {
+
+	@Mock AddressRepository addressRepository;
+	@InjectMocks AddressService addressService;
+
+	private User createCustomer(String username) {
+		return User.createUser(username, "닉네임", username + "@example.com", "encodedPw", UserRole.CUSTOMER);
+	}
+
+	private User createMaster() {
+		return User.createUser("master1", "관리자", "master@example.com", "encodedPw", UserRole.MASTER);
+	}
+
+	private Address createAddress(User user, boolean isDefault) {
+		return Address.createAddress("집", "서울시 강남구", "101호", "06000", isDefault, user);
+	}
+
+	// ─── createAddress ───────────────────────────────────────────────────────
+
+	@Test
+	@DisplayName("배송지 생성 성공 - 기본 배송지가 아닌 경우 그대로 저장된다")
+	void createAddress_nonDefault_savesAndReturns() {
+		User user = createCustomer("user1234");
+		AddressCreateRequest request = new AddressCreateRequest("집", "서울시 강남구", "101호", "06000", false);
+		Address saved = createAddress(user, false);
+		given(addressRepository.save(any())).willReturn(saved);
+
+		AddressResponse result = addressService.createAddress(request, user);
+
+		assertThat(result.address()).isEqualTo("서울시 강남구");
+		assertThat(result.isDefault()).isFalse();
+	}
+
+	@Test
+	@DisplayName("배송지 생성 성공 - 기본 배송지로 생성 시 기존 기본 배송지가 해제된다")
+	void createAddress_withDefault_disablesPreviousDefault() {
+		User user = createCustomer("user1234");
+		Address existing = createAddress(user, true);
+		given(addressRepository.findByUserAndIsDefaultTrue(user)).willReturn(Optional.of(existing));
+		Address saved = createAddress(user, true);
+		given(addressRepository.save(any())).willReturn(saved);
+
+		AddressCreateRequest request = new AddressCreateRequest("회사", "서울시 종로구", "202호", "03000", true);
+		addressService.createAddress(request, user);
+
+		assertThat(existing.isDefault()).isFalse();
+	}
+
+	// ─── getAddresses ────────────────────────────────────────────────────────
+
+	@Test
+	@DisplayName("배송지 목록 조회 성공 - CUSTOMER는 본인 배송지만 조회된다")
+	void getAddresses_customer_returnsOwnAddresses() {
+		User user = createCustomer("user1234");
+		Address address = createAddress(user, false);
+		given(addressRepository.findByUser(user, PageRequest.of(0, 10)))
+			.willReturn(new PageImpl<>(List.of(address)));
+
+		Page<AddressResponse> result = addressService.getAddresses(user, PageRequest.of(0, 10));
+
+		assertThat(result.getContent()).hasSize(1);
+		assertThat(result.getContent().get(0).address()).isEqualTo("서울시 강남구");
+	}
+
+	@Test
+	@DisplayName("배송지 목록 조회 성공 - MASTER는 전체 배송지가 조회된다")
+	void getAddresses_master_returnsAllAddresses() {
+		User master = createMaster();
+		User other = createCustomer("other999");
+		Address a1 = createAddress(master, false);
+		Address a2 = createAddress(other, false);
+		given(addressRepository.findAll(PageRequest.of(0, 10)))
+			.willReturn(new PageImpl<>(List.of(a1, a2)));
+
+		Page<AddressResponse> result = addressService.getAddresses(master, PageRequest.of(0, 10));
+
+		assertThat(result.getContent()).hasSize(2);
+	}
+
+	// ─── getAddress ──────────────────────────────────────────────────────────
+
+	@Test
+	@DisplayName("배송지 상세 조회 성공 - 본인이 조회한다")
+	void getAddress_owner_returnsAddress() {
+		User user = createCustomer("user1234");
+		Address address = createAddress(user, false);
+		UUID id = UUID.randomUUID();
+		given(addressRepository.findById(id)).willReturn(Optional.of(address));
+
+		AddressResponse result = addressService.getAddress(id, user);
+
+		assertThat(result.address()).isEqualTo("서울시 강남구");
+	}
+
+	@Test
+	@DisplayName("배송지 상세 조회 성공 - MASTER가 타인 배송지를 조회한다")
+	void getAddress_master_returnsAnyAddress() {
+		User master = createMaster();
+		User owner = createCustomer("user1234");
+		Address address = createAddress(owner, false);
+		UUID id = UUID.randomUUID();
+		given(addressRepository.findById(id)).willReturn(Optional.of(address));
+
+		assertThatCode(() -> addressService.getAddress(id, master)).doesNotThrowAnyException();
+	}
+
+	@Test
+	@DisplayName("배송지 상세 조회 실패 - 타인 배송지 조회 시 ACCESS_DENIED 예외 발생")
+	void getAddress_otherUser_throwsAccessDenied() {
+		User owner = createCustomer("user1234");
+		User other = createCustomer("other999");
+		Address address = createAddress(owner, false);
+		UUID id = UUID.randomUUID();
+		given(addressRepository.findById(id)).willReturn(Optional.of(address));
+
+		assertThatThrownBy(() -> addressService.getAddress(id, other))
+			.isInstanceOf(CustomException.class)
+			.extracting("errorCode").isEqualTo(ErrorCode.ACCESS_DENIED);
+	}
+
+	@Test
+	@DisplayName("배송지 상세 조회 실패 - 존재하지 않는 배송지 시 ADDRESS_NOT_FOUND 예외 발생")
+	void getAddress_notFound_throwsAddressNotFound() {
+		User user = createCustomer("user1234");
+		UUID id = UUID.randomUUID();
+		given(addressRepository.findById(id)).willReturn(Optional.empty());
+
+		assertThatThrownBy(() -> addressService.getAddress(id, user))
+			.isInstanceOf(CustomException.class)
+			.extracting("errorCode").isEqualTo(ErrorCode.ADDRESS_NOT_FOUND);
+	}
+
+	// ─── updateAddress ───────────────────────────────────────────────────────
+
+	@Test
+	@DisplayName("배송지 수정 성공 - 본인이 수정한다")
+	void updateAddress_owner_returnsUpdated() {
+		User user = createCustomer("user1234");
+		Address address = createAddress(user, false);
+		UUID id = UUID.randomUUID();
+		given(addressRepository.findById(id)).willReturn(Optional.of(address));
+
+		AddressUpdateRequest request = new AddressUpdateRequest("회사", "서울시 종로구", "202호", "03000", false);
+		AddressResponse result = addressService.updateAddress(id, request, user);
+
+		assertThat(result.address()).isEqualTo("서울시 종로구");
+		assertThat(result.alias()).isEqualTo("회사");
+	}
+
+	@Test
+	@DisplayName("배송지 수정 성공 - 기본 배송지로 변경 시 기존 기본 배송지가 해제된다")
+	void updateAddress_setDefault_disablesPreviousDefault() {
+		User user = createCustomer("user1234");
+		Address existing = createAddress(user, true);
+		Address target = createAddress(user, false);
+		UUID id = UUID.randomUUID();
+		given(addressRepository.findById(id)).willReturn(Optional.of(target));
+		given(addressRepository.findByUserAndIsDefaultTrue(user)).willReturn(Optional.of(existing));
+
+		AddressUpdateRequest request = new AddressUpdateRequest("회사", "서울시 종로구", "202호", "03000", true);
+		addressService.updateAddress(id, request, user);
+
+		assertThat(existing.isDefault()).isFalse();
+		assertThat(target.isDefault()).isTrue();
+	}
+
+	@Test
+	@DisplayName("배송지 수정 실패 - 타인 배송지 수정 시 ACCESS_DENIED 예외 발생")
+	void updateAddress_otherUser_throwsAccessDenied() {
+		User owner = createCustomer("user1234");
+		User other = createCustomer("other999");
+		Address address = createAddress(owner, false);
+		UUID id = UUID.randomUUID();
+		given(addressRepository.findById(id)).willReturn(Optional.of(address));
+
+		AddressUpdateRequest request = new AddressUpdateRequest("회사", "서울시 종로구", "202호", "03000", false);
+
+		assertThatThrownBy(() -> addressService.updateAddress(id, request, other))
+			.isInstanceOf(CustomException.class)
+			.extracting("errorCode").isEqualTo(ErrorCode.ACCESS_DENIED);
+	}
+
+	@Test
+	@DisplayName("배송지 수정 실패 - 존재하지 않는 배송지 시 ADDRESS_NOT_FOUND 예외 발생")
+	void updateAddress_notFound_throwsAddressNotFound() {
+		User user = createCustomer("user1234");
+		UUID id = UUID.randomUUID();
+		given(addressRepository.findById(id)).willReturn(Optional.empty());
+
+		AddressUpdateRequest request = new AddressUpdateRequest("회사", "서울시 종로구", "202호", "03000", false);
+
+		assertThatThrownBy(() -> addressService.updateAddress(id, request, user))
+			.isInstanceOf(CustomException.class)
+			.extracting("errorCode").isEqualTo(ErrorCode.ADDRESS_NOT_FOUND);
+	}
+
+	// ─── deleteAddress ───────────────────────────────────────────────────────
+
+	@Test
+	@DisplayName("배송지 삭제 성공 - 본인이 소프트 삭제되고 deletedAt이 설정된다")
+	void deleteAddress_owner_softDeletes() {
+		User user = createCustomer("user1234");
+		Address address = createAddress(user, false);
+		UUID id = UUID.randomUUID();
+		given(addressRepository.findById(id)).willReturn(Optional.of(address));
+
+		addressService.deleteAddress(id, user);
+
+		assertThat(address.getDeletedAt()).isNotNull();
+		assertThat(address.getDeletedBy()).isEqualTo("user1234");
+	}
+
+	@Test
+	@DisplayName("배송지 삭제 성공 - MASTER가 타인 배송지를 소프트 삭제한다")
+	void deleteAddress_master_softDeletes() {
+		User master = createMaster();
+		User owner = createCustomer("user1234");
+		Address address = createAddress(owner, false);
+		UUID id = UUID.randomUUID();
+		given(addressRepository.findById(id)).willReturn(Optional.of(address));
+
+		addressService.deleteAddress(id, master);
+
+		assertThat(address.getDeletedAt()).isNotNull();
+		assertThat(address.getDeletedBy()).isEqualTo("master1");
+	}
+
+	@Test
+	@DisplayName("배송지 삭제 실패 - 타인 배송지 삭제 시 ACCESS_DENIED 예외 발생")
+	void deleteAddress_otherUser_throwsAccessDenied() {
+		User owner = createCustomer("user1234");
+		User other = createCustomer("other999");
+		Address address = createAddress(owner, false);
+		UUID id = UUID.randomUUID();
+		given(addressRepository.findById(id)).willReturn(Optional.of(address));
+
+		assertThatThrownBy(() -> addressService.deleteAddress(id, other))
+			.isInstanceOf(CustomException.class)
+			.extracting("errorCode").isEqualTo(ErrorCode.ACCESS_DENIED);
+	}
+
+	@Test
+	@DisplayName("배송지 삭제 실패 - 존재하지 않는 배송지 시 ADDRESS_NOT_FOUND 예외 발생")
+	void deleteAddress_notFound_throwsAddressNotFound() {
+		User user = createCustomer("user1234");
+		UUID id = UUID.randomUUID();
+		given(addressRepository.findById(id)).willReturn(Optional.empty());
+
+		assertThatThrownBy(() -> addressService.deleteAddress(id, user))
+			.isInstanceOf(CustomException.class)
+			.extracting("errorCode").isEqualTo(ErrorCode.ADDRESS_NOT_FOUND);
+	}
+
+	// ─── setDefaultAddress ───────────────────────────────────────────────────
+
+	@Test
+	@DisplayName("기본 배송지 설정 성공 - 기존 기본 배송지 해제 후 새 배송지가 기본으로 설정된다")
+	void setDefaultAddress_success_replacesDefault() {
+		User user = createCustomer("user1234");
+		Address prev = createAddress(user, true);
+		Address target = createAddress(user, false);
+		UUID id = UUID.randomUUID();
+		given(addressRepository.findById(id)).willReturn(Optional.of(target));
+		given(addressRepository.findByUserAndIsDefaultTrue(user)).willReturn(Optional.of(prev));
+
+		addressService.setDefaultAddress(id, user);
+
+		assertThat(prev.isDefault()).isFalse();
+		assertThat(target.isDefault()).isTrue();
+	}
+
+	@Test
+	@DisplayName("기본 배송지 설정 실패 - 타인 배송지 설정 시 ACCESS_DENIED 예외 발생")
+	void setDefaultAddress_otherUser_throwsAccessDenied() {
+		User owner = createCustomer("user1234");
+		User other = createCustomer("other999");
+		Address address = createAddress(owner, false);
+		UUID id = UUID.randomUUID();
+		given(addressRepository.findById(id)).willReturn(Optional.of(address));
+
+		assertThatThrownBy(() -> addressService.setDefaultAddress(id, other))
+			.isInstanceOf(CustomException.class)
+			.extracting("errorCode").isEqualTo(ErrorCode.ACCESS_DENIED);
+	}
+
+	@Test
+	@DisplayName("기본 배송지 설정 실패 - 존재하지 않는 배송지 시 ADDRESS_NOT_FOUND 예외 발생")
+	void setDefaultAddress_notFound_throwsAddressNotFound() {
+		User user = createCustomer("user1234");
+		UUID id = UUID.randomUUID();
+		given(addressRepository.findById(id)).willReturn(Optional.empty());
+
+		assertThatThrownBy(() -> addressService.setDefaultAddress(id, user))
+			.isInstanceOf(CustomException.class)
+			.extracting("errorCode").isEqualTo(ErrorCode.ADDRESS_NOT_FOUND);
+	}
+}


### PR DESCRIPTION
## ✨ 작업 내용
> Address CRUD 및 기본 배송지 설정 기능 구현
> Address 목록 조회시 관리자와 사용자 다른 응답 제공
> 이미 기본 배송지인 경우 불필요한 업데이트 방지를 위해 조기 리턴 로직 추가
> 기본 배송지 해제 시 삭제되지 않은(soft-delete) 데이터만 조회하도록 필터링 조건 추가

## 📸 스크린샷(선택)
> 스크린샷이 필요한 작업이면 스크린샷을 첨부해주세요

## ✅ 테스트
- [x] AddressService 단위 테스트 정상 동작 확인
- [x] AddressController 테스트 정상 동작 확인

## 📚 레퍼런스 (또는 새로 알게 된 내용) 혹은 궁금한 사항들
> 조금 서둘러 만들어서 놓친 부분이 있을 수도 있으니 발견하시면 코멘트 달아주세요~