### PR TITLE
Feature/auth

### DIFF
--- a/src/main/java/com/sparta/deliveryorderplatform/auth/controller/AuthController.java
+++ b/src/main/java/com/sparta/deliveryorderplatform/auth/controller/AuthController.java
@@ -3,6 +3,7 @@ package com.sparta.deliveryorderplatform.auth.controller;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -40,9 +41,9 @@ public class AuthController {
 
 	@PostMapping("/logout")
 	public ResponseEntity<ApiResponse<Void>> logout(
-		@AuthenticationPrincipal String username // TODO: 추후 로그인 사용자로 교체
+		@AuthenticationPrincipal UserDetails userDetails
 	) {
-		authService.logout(username);
+		authService.logout(userDetails.getUsername());
 		return ResponseEntity.ok(ApiResponse.success());
 	}
 }

--- a/src/main/java/com/sparta/deliveryorderplatform/auth/dto/LoginResponseDto.java
+++ b/src/main/java/com/sparta/deliveryorderplatform/auth/dto/LoginResponseDto.java
@@ -1,10 +1,14 @@
 package com.sparta.deliveryorderplatform.auth.dto;
 
+import com.sparta.deliveryorderplatform.user.entity.UserRole;
+
 public record LoginResponseDto(
 	String accessToken,
-	String refreshToken
+	String refreshToken,
+	String username,
+	UserRole role
 ) {
-	public static LoginResponseDto of(String accessToken, String refreshToken) {
-		return new LoginResponseDto(accessToken, refreshToken);
+	public static LoginResponseDto of(String accessToken, String refreshToken, String username, UserRole role) {
+		return new LoginResponseDto(accessToken, refreshToken, username, role);
 	}
 }

--- a/src/main/java/com/sparta/deliveryorderplatform/auth/service/AuthService.java
+++ b/src/main/java/com/sparta/deliveryorderplatform/auth/service/AuthService.java
@@ -62,6 +62,11 @@ public class AuthService {
 		User user = userRepository.findById(requestDto.username())
 			.orElseThrow(() -> new CustomException(ErrorCode.LOGIN_FAILED));
 
+		// 삭제된 사용자 확인
+		if (user.getDeletedAt() != null) {
+			throw new CustomException(ErrorCode.LOGIN_FAILED);
+		}
+
 		// 비밀번호 확인
 		if (!passwordEncoder.matches(requestDto.password(), user.getPassword())) {
 			throw new CustomException(ErrorCode.LOGIN_FAILED);
@@ -71,7 +76,7 @@ public class AuthService {
 		String accessToken = jwtTokenProvider.createAccessToken(user.getUsername(), user.getRole());
 		String refreshToken = jwtTokenProvider.createRefreshToken(user.getUsername());
 
-		return LoginResponseDto.of(accessToken, refreshToken);
+		return LoginResponseDto.of(accessToken, refreshToken, user.getUsername(), user.getRole());
 	}
 
 	@Transactional

--- a/src/main/java/com/sparta/deliveryorderplatform/user/controller/UserController.java
+++ b/src/main/java/com/sparta/deliveryorderplatform/user/controller/UserController.java
@@ -1,11 +1,15 @@
 package com.sparta.deliveryorderplatform.user.controller;
 
+import java.util.Set;
+
+import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -32,6 +36,8 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class UserController {
 
+	private static final Set<Integer> ALLOWED_PAGE_SIZES = Set.of(10, 30, 50);
+
 	private final UserService userService;
 
 	// 사용자 목록 조회 (MASTER만 가능)
@@ -41,7 +47,10 @@ public class UserController {
 		UserSearchCondition condition,
 		@PageableDefault(size = 10, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable
 	) {
-		return ResponseEntity.ok(ApiResponse.success(PageResponse.of(userService.getUsers(condition, pageable))));
+		Pageable validated = ALLOWED_PAGE_SIZES.contains(pageable.getPageSize())
+			? pageable
+			: PageRequest.of(pageable.getPageNumber(), 10, pageable.getSort());
+		return ResponseEntity.ok(ApiResponse.success(PageResponse.of(userService.getUsers(condition, validated))));
 	}
 
 	// 사용자 상세 조회
@@ -64,7 +73,7 @@ public class UserController {
 	}
 
 	// 사용자 삭제
-	@PatchMapping("/{username}")
+	@DeleteMapping("/{username}")
 	public ResponseEntity<ApiResponse<Void>> deleteUser(
 		@PathVariable String username,
 		@AuthenticationPrincipal UserDetailsImpl userDetails

--- a/src/main/java/com/sparta/deliveryorderplatform/user/dto/UserSearchCondition.java
+++ b/src/main/java/com/sparta/deliveryorderplatform/user/dto/UserSearchCondition.java
@@ -3,7 +3,6 @@ package com.sparta.deliveryorderplatform.user.dto;
 import com.sparta.deliveryorderplatform.user.entity.UserRole;
 
 public record UserSearchCondition(
-	String username,
-	String nickname,
+	String keyword,
 	UserRole role
 ) {}

--- a/src/main/java/com/sparta/deliveryorderplatform/user/repository/UserRepositoryImpl.java
+++ b/src/main/java/com/sparta/deliveryorderplatform/user/repository/UserRepositoryImpl.java
@@ -9,6 +9,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.support.PageableExecutionUtils;
 
+import com.querydsl.core.types.OrderSpecifier;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
@@ -29,12 +30,11 @@ public class UserRepositoryImpl implements UserRepositoryCustom {
 		List<User> content = queryFactory
 			.selectFrom(user)
 			.where(
-				usernameEq(condition.username()),
-				nicknameContains(condition.nickname()),
+				keywordSearch(condition.keyword()),
 				roleEq(condition.role()),
-				user.deletedAt.isNull() // 소프트 삭제 제외
+				user.deletedAt.isNull()
 			)
-			.orderBy(user.createdAt.desc()) // 기본 정렬 (필요시 Pageable의 sort 적용 가능)
+			.orderBy(orderSpecifiers(pageable))
 			.offset(pageable.getOffset())
 			.limit(pageable.getPageSize())
 			.fetch();
@@ -44,27 +44,42 @@ public class UserRepositoryImpl implements UserRepositoryCustom {
 			.select(user.count())
 			.from(user)
 			.where(
-				usernameEq(condition.username()),
-				nicknameContains(condition.nickname()),
+				keywordSearch(condition.keyword()),
 				roleEq(condition.role()),
 				user.deletedAt.isNull()
 			);
 
-		// 3. Page 객체 반환 (PageableExecutionUtils 사용 시 카운트 쿼리 최적화 가능)
 		return PageableExecutionUtils.getPage(content, pageable, countQuery::fetchOne);
 	}
 
 	// --- 동적 조건 메서드 (BooleanExpression) ---
 
-	private BooleanExpression usernameEq(String username) {
-		return hasText(username) ? user.username.eq(username) : null;
-	}
-
-	private BooleanExpression nicknameContains(String nickname) {
-		return hasText(nickname) ? user.nickname.contains(nickname) : null;
+	private BooleanExpression keywordSearch(String keyword) {
+		if (!hasText(keyword)) return null;
+		return user.username.eq(keyword).or(user.nickname.contains(keyword));
 	}
 
 	private BooleanExpression roleEq(UserRole role) {
 		return role != null ? user.role.eq(role) : null;
+	}
+
+	// --- 정렬 ---
+
+	@SuppressWarnings("rawtypes")
+	private OrderSpecifier[] orderSpecifiers(Pageable pageable) {
+		if (!pageable.getSort().isSorted()) {
+			return new OrderSpecifier[]{user.createdAt.desc()};
+		}
+		return pageable.getSort().stream()
+			.map(order -> {
+				boolean asc = order.isAscending();
+				return switch (order.getProperty()) {
+					case "username" -> asc ? user.username.asc() : user.username.desc();
+					case "nickname" -> asc ? user.nickname.asc() : user.nickname.desc();
+					case "updatedAt" -> asc ? user.updatedAt.asc() : user.updatedAt.desc();
+					default -> asc ? user.createdAt.asc() : user.createdAt.desc();
+				};
+			})
+			.toArray(OrderSpecifier[]::new);
 	}
 }

--- a/src/main/java/com/sparta/deliveryorderplatform/user/security/UserDetailsImpl.java
+++ b/src/main/java/com/sparta/deliveryorderplatform/user/security/UserDetailsImpl.java
@@ -55,5 +55,5 @@ public class UserDetailsImpl implements UserDetails {
 	public boolean isCredentialsNonExpired() { return true; }
 
 	@Override
-	public boolean isEnabled() { return true; }
+	public boolean isEnabled() { return user.getDeletedAt() == null; }
 }

--- a/src/main/java/com/sparta/deliveryorderplatform/user/security/UserDetailsServiceImpl.java
+++ b/src/main/java/com/sparta/deliveryorderplatform/user/security/UserDetailsServiceImpl.java
@@ -21,6 +21,10 @@ public class UserDetailsServiceImpl implements UserDetailsService {
 		User user = userRepository.findById(username)
 			.orElseThrow(() -> new UsernameNotFoundException("Not Found " + username));
 
+		if (user.getDeletedAt() != null) {
+			throw new UsernameNotFoundException("Deleted user: " + username);
+		}
+
 		return new UserDetailsImpl(user);
 	}
 }

--- a/src/test/java/com/sparta/deliveryorderplatform/auth/controller/AuthControllerTest.java
+++ b/src/test/java/com/sparta/deliveryorderplatform/auth/controller/AuthControllerTest.java
@@ -1,25 +1,12 @@
 package com.sparta.deliveryorderplatform.auth.controller;
 
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.BDDMockito.given;
-import static org.mockito.BDDMockito.willThrow;
-import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.authentication;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.BDDMockito.*;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 import java.util.List;
-
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.sparta.deliveryorderplatform.auth.dto.LoginRequestDto;
-import com.sparta.deliveryorderplatform.auth.dto.LoginResponseDto;
-import com.sparta.deliveryorderplatform.auth.dto.SignUpRequestDto;
-import com.sparta.deliveryorderplatform.auth.jwt.JwtAuthenticationEntryPoint;
-import com.sparta.deliveryorderplatform.auth.jwt.JwtTokenProvider;
-import com.sparta.deliveryorderplatform.auth.service.AuthService;
-import com.sparta.deliveryorderplatform.global.exception.CustomException;
-import com.sparta.deliveryorderplatform.global.exception.ErrorCode;
-import com.sparta.deliveryorderplatform.user.entity.UserRole;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -32,7 +19,17 @@ import org.springframework.security.authentication.UsernamePasswordAuthenticatio
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.test.web.servlet.MockMvc;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.sparta.deliveryorderplatform.auth.dto.LoginRequestDto;
+import com.sparta.deliveryorderplatform.auth.dto.LoginResponseDto;
+import com.sparta.deliveryorderplatform.auth.dto.SignUpRequestDto;
+import com.sparta.deliveryorderplatform.auth.jwt.JwtAuthenticationEntryPoint;
+import com.sparta.deliveryorderplatform.auth.jwt.JwtTokenProvider;
+import com.sparta.deliveryorderplatform.auth.service.AuthService;
 import com.sparta.deliveryorderplatform.global.config.SecurityConfig;
+import com.sparta.deliveryorderplatform.global.exception.CustomException;
+import com.sparta.deliveryorderplatform.global.exception.ErrorCode;
+import com.sparta.deliveryorderplatform.user.entity.UserRole;
 
 @WebMvcTest(AuthController.class)
 @Import({SecurityConfig.class, JwtAuthenticationEntryPoint.class})
@@ -146,7 +143,8 @@ class AuthControllerTest {
 	@DisplayName("로그인 성공 - 200과 액세스·리프레시 토큰을 반환한다")
 	void login_success_returns200WithTokens() throws Exception {
 		LoginRequestDto request = new LoginRequestDto("user1234", "Password1!");
-		given(authService.login(any())).willReturn(LoginResponseDto.of("accessToken", "refreshToken"));
+		UserRole role = UserRole.CUSTOMER;
+		given(authService.login(any())).willReturn(LoginResponseDto.of("accessToken", "refreshToken", request.username(), role));
 
 		mockMvc.perform(post("/api/v1/auth/signup/login")
 				.contentType(MediaType.APPLICATION_JSON)
@@ -154,7 +152,9 @@ class AuthControllerTest {
 			.andExpect(status().isOk())
 			.andExpect(jsonPath("$.message").value("SUCCESS"))
 			.andExpect(jsonPath("$.data.accessToken").value("accessToken"))
-			.andExpect(jsonPath("$.data.refreshToken").value("refreshToken"));
+			.andExpect(jsonPath("$.data.refreshToken").value("refreshToken"))
+			.andExpect(jsonPath("$.data.username").value("user1234"))
+			.andExpect(jsonPath("$.data.role").value(role.name()));
 	}
 
 	@Test

--- a/src/test/java/com/sparta/deliveryorderplatform/auth/service/AuthServiceTest.java
+++ b/src/test/java/com/sparta/deliveryorderplatform/auth/service/AuthServiceTest.java
@@ -121,6 +121,20 @@ class AuthServiceTest {
 	}
 
 	@Test
+	@DisplayName("로그인 실패 - 소프트 삭제된 사용자는 LOGIN_FAILED 예외 발생")
+	void login_deletedUser_throwsLoginFailed() {
+		LoginRequestDto request = new LoginRequestDto("user1234", "Password1!");
+		User user = User.createUser("user1234", "닉네임", "test@example.com", "encodedPassword", UserRole.CUSTOMER);
+		user.softDelete("admin");
+
+		given(userRepository.findById("user1234")).willReturn(Optional.of(user));
+
+		assertThatThrownBy(() -> authService.login(request))
+			.isInstanceOf(CustomException.class)
+			.extracting("errorCode").isEqualTo(ErrorCode.LOGIN_FAILED);
+	}
+
+	@Test
 	@DisplayName("로그인 실패 - 존재하지 않는 아이디 시 LOGIN_FAILED 예외 발생")
 	void login_userNotFound_throwsLoginFailed() {
 		LoginRequestDto request = new LoginRequestDto("nouser1", "Password1!");

--- a/src/test/java/com/sparta/deliveryorderplatform/user/controller/UserControllerTest.java
+++ b/src/test/java/com/sparta/deliveryorderplatform/user/controller/UserControllerTest.java
@@ -95,6 +95,28 @@ class UserControllerTest {
 			.andExpect(status().isForbidden());
 	}
 
+	@Test
+	@DisplayName("사용자 목록 조회 성공 - keyword 파라미터로 조회하면 200을 반환한다")
+	void getUsers_withKeyword_returns200() throws Exception {
+		given(userService.getUsers(any(), any())).willReturn(Page.empty());
+
+		mockMvc.perform(get("/api/v1/users")
+				.param("keyword", "홍길동")
+				.with(authentication(masterAuth())))
+			.andExpect(status().isOk());
+	}
+
+	@Test
+	@DisplayName("사용자 목록 조회 성공 - 허용되지 않는 size는 10으로 보정되어 200을 반환한다")
+	void getUsers_invalidSize_correctedTo10() throws Exception {
+		given(userService.getUsers(any(), any())).willReturn(Page.empty());
+
+		mockMvc.perform(get("/api/v1/users")
+				.param("size", "7")
+				.with(authentication(masterAuth())))
+			.andExpect(status().isOk());
+	}
+
 	// ─── GET /api/v1/users/{username} ────────────────────────────────────────
 
 	@Test

--- a/src/test/java/com/sparta/deliveryorderplatform/user/security/UserDetailsServiceImplTest.java
+++ b/src/test/java/com/sparta/deliveryorderplatform/user/security/UserDetailsServiceImplTest.java
@@ -1,0 +1,63 @@
+package com.sparta.deliveryorderplatform.user.security;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+
+import java.util.Optional;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+
+import com.sparta.deliveryorderplatform.user.entity.User;
+import com.sparta.deliveryorderplatform.user.entity.UserRole;
+import com.sparta.deliveryorderplatform.user.repository.UserRepository;
+
+@ExtendWith(MockitoExtension.class)
+class UserDetailsServiceImplTest {
+
+	@Mock UserRepository userRepository;
+	@InjectMocks UserDetailsServiceImpl userDetailsService;
+
+	private User createCustomer(String username) {
+		return User.createUser(username, "닉네임", username + "@example.com", "encodedPassword", UserRole.CUSTOMER);
+	}
+
+	@Test
+	@DisplayName("정상 사용자 로드 성공 - UserDetailsImpl을 반환한다")
+	void loadUserByUsername_activeUser_returnsUserDetails() {
+		User user = createCustomer("user1234");
+		given(userRepository.findById("user1234")).willReturn(Optional.of(user));
+
+		UserDetails result = userDetailsService.loadUserByUsername("user1234");
+
+		assertThat(result.getUsername()).isEqualTo("user1234");
+		assertThat(result.isEnabled()).isTrue();
+	}
+
+	@Test
+	@DisplayName("소프트 삭제된 사용자 - UsernameNotFoundException 발생")
+	void loadUserByUsername_deletedUser_throwsUsernameNotFoundException() {
+		User user = createCustomer("user1234");
+		user.softDelete("admin");
+		given(userRepository.findById("user1234")).willReturn(Optional.of(user));
+
+		assertThatThrownBy(() -> userDetailsService.loadUserByUsername("user1234"))
+			.isInstanceOf(UsernameNotFoundException.class);
+	}
+
+	@Test
+	@DisplayName("존재하지 않는 사용자 - UsernameNotFoundException 발생")
+	void loadUserByUsername_notFound_throwsUsernameNotFoundException() {
+		given(userRepository.findById("ghost123")).willReturn(Optional.empty());
+
+		assertThatThrownBy(() -> userDetailsService.loadUserByUsername("ghost123"))
+			.isInstanceOf(UsernameNotFoundException.class);
+	}
+}

--- a/src/test/java/com/sparta/deliveryorderplatform/user/service/UserServiceTest.java
+++ b/src/test/java/com/sparta/deliveryorderplatform/user/service/UserServiceTest.java
@@ -55,7 +55,7 @@ class UserServiceTest {
 		given(userRepository.searchUsers(any(), any())).willReturn(new PageImpl<>(List.of(user)));
 
 		Page<UserResponseDto> result = userService.getUsers(
-			new UserSearchCondition(null, null, null),
+			new UserSearchCondition(null, null),
 			PageRequest.of(0, 10)
 		);
 


### PR DESCRIPTION
## ✨ 작업 내용
> SA해설 세션에 맞지 않는 부분 수정
> 로그인 응답에 username, role 추가
> 소프트 삭제된 사용자의 인증 차단
> 사용자 목록 조회 Search 파라미터 스펙 준수

## 📸 스크린샷(선택)
> 스크린샷이 필요한 작업이면 스크린샷을 첨부해주세요

## ✅ 테스트
- [x] 소프트 삭제된 사용자 로그인 시도 → LOGIN_FAILED 반환 확인
- [x] 소프트 삭제된 사용자의 기존 토큰으로 API 요청 → 401 반환 확인
- [x] keyword=홍길동 파라미터로 username 일치 / nickname 포함 검색 동작 확인
- [x] size=7 입력 시 size=10으로 보정 확인

## 📚 레퍼런스 (또는 새로 알게 된 내용) 혹은 궁금한 사항들
> 참고할 사항이 있다면 적어주세요